### PR TITLE
add check for breakpoint

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/carbon_sensitivity/CarbonSensitivitySummary.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/carbon_sensitivity/CarbonSensitivitySummary.scala
@@ -121,6 +121,11 @@ object CarbonSensitivitySummary {
 
         val thresholds = List(0, 10, 15, 20, 25, 30, 50, 75)
 
+        if (isLoss && (grossEmissionsCo2eNoneCo2Pixel == 0 || grossEmissionsCo2eCo2Only == 0)) {
+          val lat: Double = raster.rasterExtent.gridRowToMap(row)
+          val lng: Double = raster.rasterExtent.gridColToMap(col)
+          println(lat, lng)
+        }
 
         @tailrec
         def updateSummary(


### PR DESCRIPTION
DO NOT MERGE

Use this to debug and check why for some areas there are no emission data.

You can two breakpoints
This one right before we call the summary statistics to step into the code:
https://github.com/wri/gfw_forest_loss_geotrellis/blob/5a983a033fa1d5398715b33b50002e67baf017c3/src/main/scala/org/globalforestwatch/summarystats/carbon_sensitivity/CarbonSensitivityRDD.scala#L29

Then this one to find pixels which don't have correct values
https://github.com/wri/gfw_forest_loss_geotrellis/blob/5a983a033fa1d5398715b33b50002e67baf017c3/src/main/scala/org/globalforestwatch/summarystats/carbon_sensitivity/CarbonSensitivitySummary.scala#L127

