### PR TITLE
AnnualUpdate - filter out no change rows when exporting change table

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/annualupdate_minimal/AnnualUpdateMinimalExport.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/annualupdate_minimal/AnnualUpdateMinimalExport.scala
@@ -234,6 +234,7 @@ object AnnualUpdateMinimalExport extends SummaryExport {
         .csv(path = outputUrl + "/wdpa/summary")
     }
     exportDF
+      .filter($"treecover_loss__year".isNotNull && $"treecover_loss__ha" > 0)
       .transform(AnnualUpdateMinimalDF.aggChange(idCols, wdpa = true))
       .coalesce(50) // this should result in an avg file size of 100MB
       .write
@@ -272,14 +273,15 @@ object AnnualUpdateMinimalExport extends SummaryExport {
 
       exportDF
         .transform(AnnualUpdateMinimalDF.aggSummary(idCols))
-        .coalesce(4) // this should result in an avg file size of 100MB
+        .coalesce(33) // this should result in an avg file size of 100MB
         .write
         .options(csvOptions)
         .csv(path = outputUrl + "/geostore/summary")
     }
     exportDF
+      .filter($"treecover_loss__year".isNotNull && $"treecover_loss__ha" > 0)
       .transform(AnnualUpdateMinimalDF.aggChange(idCols))
-      .coalesce(10) // this should result in an avg file size of 100MB
+      .coalesce(50) // this should result in an avg file size of 100MB
       .write
       .options(csvOptions)
       .csv(path = outputUrl + "/geostore/change")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.2"
+version in ThisBuild := "1.0.3"


### PR DESCRIPTION
For geostore and WDPA, to be on parity with GADM

Also increase number of partitions for geostore, since might get quite high.