### PR TITLE
Call distinct after PIP analysis to remove duplicates 

### DIFF
--- a/src/main/scala/org/globalforestwatch/features/FeatureRDDFactory.scala
+++ b/src/main/scala/org/globalforestwatch/features/FeatureRDDFactory.scala
@@ -29,7 +29,7 @@ object FeatureRDDFactory {
           fireSrcUris,
           fireFeatureObj,
           kwargs,
-          spark)
+          spark).distinct  // call distinct to remove duplicate PIP intersections due to how we split input geometries
       case _ =>
         FeatureRDD(featureUris, featureObj, kwargs, spark)
     }

--- a/src/main/scala/org/globalforestwatch/features/FireAlertModisFeatureId.scala
+++ b/src/main/scala/org/globalforestwatch/features/FireAlertModisFeatureId.scala
@@ -10,5 +10,5 @@ case class FireAlertModisFeatureId(
                                     brightness: Float,
                                     brightT31: Float,
                                     frp: Float) extends FeatureId {
-  override def toString: String = alertDate + " " + alertTime.toString
+  override def toString: String = alertDate + " " + alertTime.toString + " " + lon.toString + " " + lat.toString
 }

--- a/src/main/scala/org/globalforestwatch/features/FireAlertViirsFeatureId.scala
+++ b/src/main/scala/org/globalforestwatch/features/FireAlertViirsFeatureId.scala
@@ -9,5 +9,5 @@ case class FireAlertViirsFeatureId(
                                     brightTi4: Float,
                                     brightTi5: Float,
                                     frp: Float) extends FeatureId {
-  override def toString: String = alertDate + " " + alertTime.toString
+  override def toString: String = alertDate + " " + alertTime.toString + " " + lon.toString + " " + lat.toString
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Since we cut up features to 1x1 tiles, sometimes there's an alert point exactly on the border of where we cut up the feature. When doing the GeoSpark spatial join, this creates two join records, one for each piece of the feature. We then later merge the points by feature, which causes it to get counted twice. 


## What is the new behavior?
Simplest solution is just to call distinct on the RDD after doing the PIP analysis to remove duplicates from the join. Already ran it on the entire VIIRS archive, and even though it causes a shuffle, it only takes like 30 seconds. 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

