### PR TITLE
Burned Areas Partitioning and Other Fixes

### DIFF
--- a/src/main/scala/org/globalforestwatch/features/FeatureIdFactory.scala
+++ b/src/main/scala/org/globalforestwatch/features/FeatureIdFactory.scala
@@ -82,7 +82,7 @@ case class FeatureIdFactory(featureType: String) {
     featureType match {
       case "gadm" => GadmFeature.getFeatureId(values, true)
       case "feature" => SimpleFeatureId(values(0).toInt)
-      case "wdpa" => GadmFeature.getFeatureId(values, true)
+      case "wdpa" => WdpaFeature.getFeatureId(values, true)
       case "geostore" => GeostoreFeature.getFeatureId(values, true)
       case "burned_areas" => BurnedAreasFeature.getFeatureId(values, true)
       case "viirs" => FireAlertViirsFeature.getFeatureId(values, true)

--- a/src/main/scala/org/globalforestwatch/features/FeatureRDDFactory.scala
+++ b/src/main/scala/org/globalforestwatch/features/FeatureRDDFactory.scala
@@ -38,12 +38,12 @@ object FeatureRDDFactory {
               getAnyMapValue[NonEmptyList[String]](kwargs, "fireAlertSource")
 
             FeatureRDD(
-              featureType,
-              featureUris,
-              "\t",
               fireAlertType,
               burnedAreasUris,
               ",",
+              featureType,
+              featureUris,
+              "\t",
               kwargs,
               spark
             )

--- a/src/main/scala/org/globalforestwatch/features/PolygonIntersectionDF.scala
+++ b/src/main/scala/org/globalforestwatch/features/PolygonIntersectionDF.scala
@@ -9,6 +9,13 @@ import org.globalforestwatch.util.Util.getAnyMapValue
 import org.apache.spark.sql.functions.{col, expr}
 
 object PolygonIntersectionDF {
+  /*
+    Applies a spatial join between two polygonal datasets using GeoSpark, returning the
+    intersecting polygons with combined attributes.
+
+    NOTE: The spatial join will partition/index on feature 1, so typically feature 1 should
+    be the larger dataset.
+   */
   def apply(feature1Uris: NonEmptyList[String],
             feature1Type: String,
             feature2Uris: NonEmptyList[String],
@@ -35,7 +42,6 @@ object PolygonIntersectionDF {
 
     feature1DF.createOrReplaceTempView("left")
     feature2DF.createOrReplaceTempView("right")
-
 
     spark.sql(
       "SELECT " +

--- a/src/main/scala/org/globalforestwatch/features/WdpaFeature.scala
+++ b/src/main/scala/org/globalforestwatch/features/WdpaFeature.scala
@@ -59,7 +59,7 @@ object WdpaFeature extends Feature {
     val isoEndDF: DataFrame =
       isoEnd.foldLeft(isoStartDF)((acc, i) => acc.filter($"iso" < i))
     val isoDF: DataFrame =
-      iso.foldLeft(isoEndDF)((acc, i) => acc.filter($"iso" === i))
+      iso.foldLeft(isoEndDF)((acc, i) => acc.filter($"iso3" === i))
 
     val wdpaIdStartDF =
       wdpaIdStart.foldLeft(isoDF)((acc, i) => acc.filter($"wdpaid" >= i))

--- a/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsAnalysis.scala
@@ -21,12 +21,12 @@ object FireAlertsAnalysis {
 
     val fireAlertType = getAnyMapValue[String](kwargs, "fireAlertType")
     val layoutDefinition = fireAlertType match {
-      case "viirs" => ViirsGrid.blockTileGrid
-      case "modis" | "burned_areas" => ModisGrid.blockTileGrid
+      case "viirs" | "burned_areas" => ViirsGrid.blockTileGrid
+      case "modis" => ModisGrid.blockTileGrid
     }
 
     val partition = fireAlertType match {
-      case "modis" | "viirs" => false
+      case "modis" | "viirs" | "burned_areas" => false
       case _ => true
     }
 

--- a/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsDFFactory.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsDFFactory.scala
@@ -59,7 +59,7 @@ case class FireAlertsDFFactory(
                     id match {
                       case combinedId: CombinedFeatureId =>
                         combinedId match {
-                          case CombinedFeatureId(gadmId: GadmFeatureId, burnedAreaId: BurnedAreasFeatureId) =>
+                          case CombinedFeatureId(burnedAreaId: BurnedAreasFeatureId, gadmId: GadmFeatureId) =>
                             BurnedAreasRowGadm(burnedAreaId, gadmId, dataGroup, data)
                           case _ =>
                             throw new IllegalArgumentException("Not a valid GADM-Burned Areas ID")
@@ -79,7 +79,7 @@ case class FireAlertsDFFactory(
                     id match {
                       case combinedId: CombinedFeatureId =>
                         combinedId match {
-                          case CombinedFeatureId(wdpaId: WdpaFeatureId, burnedAreaId: BurnedAreasFeatureId) =>
+                          case CombinedFeatureId(burnedAreaId: BurnedAreasFeatureId, wdpaId: WdpaFeatureId) =>
                             BurnedAreasRowWdpa(burnedAreaId, wdpaId, dataGroup, data)
                           case _ =>
                             throw new IllegalArgumentException("Not a valid WDPA-Burned Areas ID")
@@ -99,7 +99,7 @@ case class FireAlertsDFFactory(
                     id match {
                       case combinedId: CombinedFeatureId =>
                         combinedId match {
-                          case CombinedFeatureId(geostoreId: GeostoreFeatureId, burnedAreaId: BurnedAreasFeatureId) =>
+                          case CombinedFeatureId(burnedAreaId: BurnedAreasFeatureId, geostoreId: GeostoreFeatureId) =>
                             BurnedAreasRowGeostore(burnedAreaId, geostoreId, dataGroup, data)
                           case _ =>
                             throw new IllegalArgumentException("Not a valid Geostore-Burned Areas ID")

--- a/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsRDD.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsRDD.scala
@@ -22,8 +22,8 @@ object FireAlertsRDD extends SummaryRDD {
 
     Either.catchNonFatal {
       fireAlertType match {
-        case "viirs" => ViirsGrid.getRasterSource(windowKey, windowLayout, kwargs)
-        case "modis" | "burned_areas" => ModisGrid.getRasterSource(windowKey, windowLayout, kwargs)
+        case "viirs" | "burned_areas" => ViirsGrid.getRasterSource(windowKey, windowLayout, kwargs)
+        case "modis" => ModisGrid.getRasterSource(windowKey, windowLayout, kwargs)
       }
     }
   }

--- a/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsSummary.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsSummary.scala
@@ -73,7 +73,7 @@ object FireAlertsSummary {
             else {
               val pKey =
                 FireAlertsDataGroup(
-                  tcd2000,
+                  thresholds.head,
                   primaryForest,
                   protectedAreas,
                   aze,

--- a/src/main/scala/org/globalforestwatch/util/GeotrellisGeometryValidator.scala
+++ b/src/main/scala/org/globalforestwatch/util/GeotrellisGeometryValidator.scala
@@ -50,9 +50,13 @@ object GeotrellisGeometryValidator extends java.io.Serializable {
         else if (geom.getGeometryType != bufferedGeom.getGeometryType && geom.getGeometryType
           .contains(bufferedGeom.getGeometryType))
           makeMultiGeom(bufferedGeom)
-        else
+        else if (geom.getGeometryType != bufferedGeom.getGeometryType && bufferedGeom.getGeometryType
+          .contains(geom.getGeometryType)) {
+          // sometimes it can even turn a Polygon to a MultiPolygon, can't go back though
+          bufferedGeom
+        } else
           throw new RuntimeException(
-            s"Faied to create a valid geometry: ${geom}"
+            s"Failed to create a valid geometry: ${geom}"
           )
       } else geom
     }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Uses hash then range partitioning for burned areas.


## What is the new behavior?

- For burned areas, just use GeoSpark quadtree partitioning since it works best.
- Make sure burned areas is left dataset in spatial join, so partitioning/indexing is done on burned areas dataset.
- Fix issue where sometimes buffer geometry trick turns Polygons into MultiPolygons
- Fix bug with WDPA feature ID not being parsed correctly
- Use VIIRS grid for burned areas instead of MODIS grid

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

