### PR TITLE
Fix type-o in SEA landcover tag for Grassland/shrub

### DIFF
--- a/src/main/scala/org/globalforestwatch/layers/SEAsiaLandCover.scala
+++ b/src/main/scala/org/globalforestwatch/layers/SEAsiaLandCover.scala
@@ -18,7 +18,7 @@ case class SEAsiaLandCover(gridTile: GridTile)
     case 8 => "Oil palm plantation"
     case 9 => "Timber plantation"
     case 10 => "Mixed tree crops"
-    case 11 | 15 => "Grassland/ shrub"
+    case 11 | 15 => "Grassland/shrub"
     case 12 | 16 => "Swamp"
     case 13 | 17 => "Agriculture"
     case 14 => "Settlements"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
SEA landcover type for grassland is reported as `Grassland/ shrub` which does not match the Pro UI.

Issue Number: GP-14


## What is the new behavior?
 `Grassland/shrub` 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No