### PR TITLE
use conf file to source FCD layers based on feature flag

### DIFF
--- a/src/main/resources/feature-flag-flagship.conf
+++ b/src/main/resources/feature-flag-flagship.conf
@@ -1,0 +1,10 @@
+raster-layers {
+  BrazilBiomes: "s3://gfw-data-lake/ibge_bra_biomes/v2004/raster/epsg-4326/<gridSize>/<rowCount>/name/gdal-geotiff/<tileId>.tif"
+  IndonesiaForestArea: "s3://gfw-data-lake/idn_forest_area/v201709/raster/epsg-4326/<gridSize>/<rowCount>/class/gdal-geotiff/<tileId>.tif"
+  IntactForestLandscapes: "s3://gfw-data-lake/ifl_intact_forest_landscapes/v2018/raster/epsg-4326/<gridSize>/<rowCount>/year/gdal-geotiff/<tileId>.tif"
+  Plantations: "s3://gfw-data-lake/gfw_plantations/v2014/raster/epsg-4326/<gridSize>/<rowCount>/type/gdal-geotiff/<tileId>.tif"
+  ProtectedAreas: "s3://gfw-data-lake/wdpa_protected_areas/v202106/raster/epsg-4326/<gridSize>/<rowCount>/iucn_cat/gdal-geotiff/<tileId>.tif"
+  SEAsiaLandCover: "s3://gfw-data-lake/rspo_southeast_asia_land_cover_2010/v2013/raster/epsg-4326/<gridSize>/<rowCount>/class/gdal-geotiff/<tileId>.tif"
+  TreeCoverDensity2000: "s3://gfw-data-lake/umd_tree_cover_density_2000/v1.6/raster/epsg-4326/<gridSize>/<rowCount>/percent/gdal-geotiff/<tileId>.tif"
+  TreeCoverDensity2010: "s3://gfw-data-lake/umd_tree_cover_density_2010/v1.6/raster/epsg-4326/<gridSize>/<rowCount>/percent/gdal-geotiff/<tileId>.tif"
+}

--- a/src/main/resources/feature-flag-pro.conf
+++ b/src/main/resources/feature-flag-pro.conf
@@ -1,0 +1,9 @@
+raster-layers {
+  BrazilBiomes: "s3://gfw-data-lake/bra_biomes/v20150601/raster/epsg-4326/<gridSize>/<rowCount>/name/gdal-geotiff/<tileId>.tif"
+  IndonesiaForestArea: "s3://gfw-data-lake/idn_forest_area/v201709/raster/epsg-4326/<gridSize>/<rowCount>/class_compressed/gdal-geotiff/<tileId>.tif"
+  IntactForestLandscapes: "s3://gfw-data-lake/ifl_intact_forest_landscapes/v20180628/raster/epsg-4326/<gridSize>/<rowCount>/year/gdal-geotiff/<tileId>.tif"
+  Plantations: "s3://gfw-data-lake/gfw_plantations/v1.3/raster/epsg-4326/<gridSize>/<rowCount>/type/gdal-geotiff/<tileId>.tif"
+  ProtectedAreas: "s3://gfw-data-lake/wdpa_protected_areas/v202010/raster/epsg-4326/<gridSize>/<rowCount>/iucn_cat/gdal-geotiff/<tileId>.tif"
+  SEAsiaLandCover: "s3://gfw-data-lake/rspo_southeast_asia_land_cover_2010/v2013/raster/epsg-4326/<gridSize>/<rowCount>/land_cover_class/gdal-geotiff/<tileId>.tif"
+  TreeCoverDensity2000: "s3://gfw-data-lake/umd_tree_cover_density_2000/v1.8/raster/epsg-4326/<gridSize>/<rowCount>/percent/gdal-geotiff/<tileId>.tif"
+}

--- a/src/main/scala/org/globalforestwatch/config/GfwConfig.scala
+++ b/src/main/scala/org/globalforestwatch/config/GfwConfig.scala
@@ -1,0 +1,31 @@
+package org.globalforestwatch.config
+
+import pureconfig.generic.auto._
+import pureconfig.ConfigSource
+import com.typesafe.scalalogging.LazyLogging
+
+case class GfwConfig(
+  rasterLayers: Map[String, String]
+)
+
+object GfwConfig extends LazyLogging {
+  private var featureFlag: String = null
+  def isGfwPro: Boolean = featureFlag == "pro"
+
+  def setProFlag(isPro: Boolean) = {
+    require(featureFlag == null, "Pro feature flag already set")
+    if (isPro) featureFlag = "pro"
+    else featureFlag = "flagship"
+  }
+
+  lazy val get: GfwConfig = {
+    if (featureFlag == null) featureFlag = "flagship"
+    read(featureFlag)
+  }
+
+  def read(flag: String): GfwConfig = {
+    val confFile = s"feature-flag-$flag.conf"
+    logger.info(s"Reading $confFile")
+    ConfigSource.resources(confFile).loadOrThrow[GfwConfig]
+  }
+}

--- a/src/main/scala/org/globalforestwatch/layers/BrazilBiomes.scala
+++ b/src/main/scala/org/globalforestwatch/layers/BrazilBiomes.scala
@@ -1,11 +1,11 @@
 package org.globalforestwatch.layers
 
 import org.globalforestwatch.grids.GridTile
+import org.globalforestwatch.config.GfwConfig
 
 case class BrazilBiomes(gridTile: GridTile) extends StringLayer with OptionalILayer {
 
-  val uri: String =
-    s"$basePath/ibge_bra_biomes/v2004/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/name/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers(getClass.getSimpleName()), gridTile)
 
   override val externalNoDataValue = "Not applicable"
 

--- a/src/main/scala/org/globalforestwatch/layers/IndonesiaForestArea.scala
+++ b/src/main/scala/org/globalforestwatch/layers/IndonesiaForestArea.scala
@@ -1,14 +1,14 @@
 package org.globalforestwatch.layers
 
 import org.globalforestwatch.grids.GridTile
+import org.globalforestwatch.config.GfwConfig
 
 case class IndonesiaForestArea(gridTile: GridTile)
   extends StringLayer
     with OptionalILayer {
 
   val datasetName = "idn_forest_area"
-  val uri: String =
-    s"$basePath/idn_forest_area/v201709/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/class/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers(getClass.getSimpleName()), gridTile)
 
   override val externalNoDataValue: String = ""
 

--- a/src/main/scala/org/globalforestwatch/layers/IndonesiaLandCover.scala
+++ b/src/main/scala/org/globalforestwatch/layers/IndonesiaLandCover.scala
@@ -1,14 +1,14 @@
 package org.globalforestwatch.layers
 
 import org.globalforestwatch.grids.GridTile
-import org.globalforestwatch.util.FeatureFlag
+import org.globalforestwatch.config.GfwConfig
 
 case class IndonesiaLandCover(gridTile: GridTile) extends StringLayer with OptionalILayer {
 
   val uri: String = s"$basePath/idn_land_cover_2017/v20180720/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/class/gdal-geotiff/${gridTile.tileId}.tif"
 
   override val externalNoDataValue: String = ""
-  private val fLookup = if (FeatureFlag.GfwPro) IndonesiaLandCover.proLabelTable else IndonesiaLandCover.flagshipLabelTable
+  private val fLookup = if (GfwConfig.isGfwPro) IndonesiaLandCover.proLabelTable else IndonesiaLandCover.flagshipLabelTable
   def lookup(value: Int): String = fLookup(value)
 }
 

--- a/src/main/scala/org/globalforestwatch/layers/IntactForestLandscapes.scala
+++ b/src/main/scala/org/globalforestwatch/layers/IntactForestLandscapes.scala
@@ -1,11 +1,12 @@
 package org.globalforestwatch.layers
 
 import org.globalforestwatch.grids.GridTile
+import org.globalforestwatch.config.GfwConfig
 
 case class IntactForestLandscapes(gridTile: GridTile)
   extends StringLayer
     with OptionalILayer {
-  val uri: String = s"$basePath/ifl_intact_forest_landscapes/v2018/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/year/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("IntactForestLandscapes"), gridTile)
 
   def lookup(value: Int): String = value match {
     case 0 => ""
@@ -18,7 +19,7 @@ case class IntactForestLandscapes(gridTile: GridTile)
 case class IntactForestLandscapes2000(gridTile: GridTile)
   extends BooleanLayer
     with OptionalILayer {
-  val uri: String = s"$basePath/ifl_intact_forest_landscapes/v20180628/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/year/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("IntactForestLandscapes"), gridTile)
 
   override def lookup(value: Int): Boolean = {
     value match {
@@ -32,7 +33,7 @@ case class IntactForestLandscapes2000(gridTile: GridTile)
 case class IntactForestLandscapes2013(gridTile: GridTile)
   extends BooleanLayer
     with OptionalILayer {
-  val uri: String = s"$basePath/ifl_intact_forest_landscapes/v20180628/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/year/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("IntactForestLandscapes"), gridTile)
 
   override def lookup(value: Int): Boolean = {
     value match {
@@ -47,7 +48,7 @@ case class IntactForestLandscapes2013(gridTile: GridTile)
 case class IntactForestLandscapes2016(gridTile: GridTile)
   extends BooleanLayer
     with OptionalILayer {
-  val uri: String = s"$basePath/ifl_intact_forest_landscapes/v2018/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/year/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("IntactForestLandscapes"), gridTile)
 
   override def lookup(value: Int): Boolean = {
     value match {

--- a/src/main/scala/org/globalforestwatch/layers/Layer.scala
+++ b/src/main/scala/org/globalforestwatch/layers/Layer.scala
@@ -20,6 +20,7 @@ import software.amazon.awssdk.services.s3.model.{
   NoSuchKeyException,
   RequestPayer
 }
+import org.globalforestwatch.grids.GridTile
 
 trait Layer {
 
@@ -34,6 +35,13 @@ trait Layer {
   val internalNoDataValue: A
   val externalNoDataValue: B
   val basePath: String = s"s3://gfw-data-lake"
+
+
+  protected def uriForGrid(template: String, grid: GridTile): String =
+    template
+      .replace("<gridSize>", grid.gridSize.toString)
+      .replace("<rowCount>", grid.rowCount.toString)
+      .replace("<tileId>", grid.tileId)
 
   def lookup(a: A): B
 }

--- a/src/main/scala/org/globalforestwatch/layers/Plantations.scala
+++ b/src/main/scala/org/globalforestwatch/layers/Plantations.scala
@@ -1,10 +1,11 @@
 package org.globalforestwatch.layers
 
 import org.globalforestwatch.grids.GridTile
+import org.globalforestwatch.config.GfwConfig
 
 case class Plantations(gridTile: GridTile) extends StringLayer with OptionalILayer {
 
-  val uri: String = s"$basePath/gfw_plantations/v2014/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/type/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("Plantations"), gridTile)
 
   def lookup(value: Int): String = value match {
     case 1  => "Fruit"
@@ -24,6 +25,6 @@ case class Plantations(gridTile: GridTile) extends StringLayer with OptionalILay
 
 case class PlantationsBool(gridTile: GridTile) extends BooleanLayer with OptionalILayer {
 
-  val uri: String = s"$basePath/gfw_plantations/v2014/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/type/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("Plantations"), gridTile)
 
 }

--- a/src/main/scala/org/globalforestwatch/layers/ProtectedAreas.scala
+++ b/src/main/scala/org/globalforestwatch/layers/ProtectedAreas.scala
@@ -1,10 +1,11 @@
 package org.globalforestwatch.layers
 
 import org.globalforestwatch.grids.GridTile
+import org.globalforestwatch.config.GfwConfig
 
 case class ProtectedAreas(gridTile: GridTile) extends StringLayer with OptionalILayer {
 
-  val uri: String = s"$basePath/wdpa_protected_areas/v202106/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/iucn_cat/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers(getClass.getSimpleName()), gridTile)
 
   def lookup(value: Int): String = value match {
     case 1 => "Category Ia/b or II"

--- a/src/main/scala/org/globalforestwatch/layers/SEAsiaLandCover.scala
+++ b/src/main/scala/org/globalforestwatch/layers/SEAsiaLandCover.scala
@@ -1,13 +1,13 @@
 package org.globalforestwatch.layers
 
 import org.globalforestwatch.grids.GridTile
+import org.globalforestwatch.config.GfwConfig
 
 case class SEAsiaLandCover(gridTile: GridTile)
     extends StringLayer
     with OptionalILayer {
 
-  val uri: String =
-    s"$basePath/rspo_southeast_asia_land_cover_2010/v2013/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/class/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers(getClass.getSimpleName()), gridTile)
 
   override val externalNoDataValue = "Unknown"
 

--- a/src/main/scala/org/globalforestwatch/layers/TreeCoverDensity.scala
+++ b/src/main/scala/org/globalforestwatch/layers/TreeCoverDensity.scala
@@ -1,6 +1,7 @@
 package org.globalforestwatch.layers
 
 import org.globalforestwatch.grids.GridTile
+import org.globalforestwatch.config.GfwConfig
 
 trait TreeCoverDensityThreshold extends IntegerLayer with RequiredILayer {
 
@@ -22,18 +23,18 @@ trait TreeCoverDensityThreshold extends IntegerLayer with RequiredILayer {
 
 case class TreeCoverDensityThreshold2000(gridTile: GridTile)
   extends TreeCoverDensityThreshold {
-  val uri: String = s"$basePath/umd_tree_cover_density_2000/v1.6/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/percent/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("TreeCoverDensity2000"), gridTile)
 }
 
 case class TreeCoverDensityThreshold2010(gridTile: GridTile)
   extends TreeCoverDensityThreshold {
-  val uri: String = s"$basePath/umd_tree_cover_density_2010/v1.6/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/percent/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("TreeCoverDensity2010"), gridTile)
 }
 
 case class TreeCoverDensity2010_60(gridTile: GridTile)
   extends BooleanLayer
     with RequiredILayer {
-  val uri: String = s"$basePath/umd_tree_cover_density_2010/v1.6/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/percent/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("TreeCoverDensity2010"), gridTile)
 
   override def lookup(value: Int): Boolean = value > 60
 
@@ -43,12 +44,12 @@ case class TreeCoverDensityPercent2000(gridTile: GridTile)
   extends IntegerLayer
     with RequiredILayer {
   override val externalNoDataValue: Integer = 0
-  val uri: String = s"$basePath/umd_tree_cover_density_2000/v1.6/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/percent/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("TreeCoverDensity2000"), gridTile)
 }
 
 case class TreeCoverDensityPercent2010(gridTile: GridTile)
   extends IntegerLayer
     with RequiredILayer {
   override val externalNoDataValue: Integer = 0
-  val uri: String = s"$basePath/umd_tree_cover_density_2010/v1.6/raster/epsg-4326/${gridTile.gridSize}/${gridTile.rowCount}/percent/gdal-geotiff/${gridTile.tileId}.tif"
+  val uri: String = uriForGrid(GfwConfig.get.rasterLayers("TreeCoverDensity2010"), gridTile)
 }

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
@@ -2,7 +2,7 @@ package org.globalforestwatch.summarystats.forest_change_diagnostic
 
 import cats.data.NonEmptyList
 import org.globalforestwatch.summarystats.SummaryCommand
-import org.globalforestwatch.util.FeatureFlag
+import org.globalforestwatch.config.GfwConfig
 import cats.implicits._
 import com.monovore.decline.Opts
 
@@ -41,7 +41,7 @@ object ForestChangeDiagnosticCommand extends SummaryCommand {
         "glad" -> defaultFilter._3
       )
 
-      FeatureFlag.GfwPro= default._6
+      GfwConfig.setProFlag(default._6)
 
       runAnalysis(ForestChangeDiagnosticAnalysis.name, default._1, default._2, kwargs)
 

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
@@ -4,6 +4,7 @@ import cats.data.NonEmptyList
 import org.globalforestwatch.summarystats.SummaryCommand
 import cats.implicits._
 import com.monovore.decline.Opts
+import org.globalforestwatch.config.GfwConfig
 
 object GfwProDashboardCommand extends SummaryCommand {
 
@@ -54,6 +55,7 @@ object GfwProDashboardCommand extends SummaryCommand {
         "admin2" -> gadmFilter._6,
       )
 
+      GfwConfig.setProFlag(default._6)
       runAnalysis(GfwProDashboardAnalysis.name, default._1, default._2, kwargs)
 
     }

--- a/src/main/scala/org/globalforestwatch/util/FeatureFlag.scala
+++ b/src/main/scala/org/globalforestwatch/util/FeatureFlag.scala
@@ -1,5 +1,0 @@
-package org.globalforestwatch.util
-
-object FeatureFlag {
-  var GfwPro: Boolean = false
-}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.7.1"
+version in ThisBuild := "1.7.2"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Currently the layers are hard-coded with URIs for their tiles, which is great.
A new nice-to-have is to be able to source two different versions of rasters for flagship and pro instances of this app so that data verification and integration can happen on their own independent schedules.


## What is the new behavior?
This PR adds the ability specify raster sources in the config files, which can be switched using the `--gfwpro` flag. 
Each source MAY use the config to get the URI template or it can continue hard-coding its URI.
This PR updates the layers required for FCD analysis because this is where the current need to maintain two versions exists.

The versions of for the PRO are pulled from "Before" state of https://github.com/wri/gfw_forest_loss_geotrellis/pull/103 because that was the last check-point for verification and UI integration.

## Does this introduce a breaking change?

- [x] Yes
- [x] No

Hard to say, may likes like the TreeCoverDensity layer and IntactForestLandscape were sourcing inconsistent versions for different version of filtered tiles. Its hard to say what analysis it would effect and I won't, but it may, so now you know.