### PR TITLE
GFW_FEATURE_FLAG

### DIFF
--- a/src/main/scala/org/globalforestwatch/config/GfwConfig.scala
+++ b/src/main/scala/org/globalforestwatch/config/GfwConfig.scala
@@ -9,19 +9,15 @@ case class GfwConfig(
 )
 
 object GfwConfig extends LazyLogging {
-  private var featureFlag: String = null
-  def isGfwPro: Boolean = featureFlag == "pro"
-
-  def setProFlag(isPro: Boolean) = {
-    require(featureFlag == null, "Pro feature flag already set")
-    if (isPro) featureFlag = "pro"
-    else featureFlag = "flagship"
+  private val featureFlag: Option[String] = {
+    val flag = scala.util.Properties.envOrNone("GFW_FEATURE_FLAG").map(_.toLowerCase())
+    logger.info(s"GFW_FEATURE_FLAG=$flag")
+    flag
   }
 
-  lazy val get: GfwConfig = {
-    if (featureFlag == null) featureFlag = "flagship"
-    read(featureFlag)
-  }
+  def isGfwPro: Boolean = featureFlag == Some("pro")
+
+  lazy val get: GfwConfig = read(featureFlag.getOrElse("pro"))
 
   def read(flag: String): GfwConfig = {
     val confFile = s"feature-flag-$flag.conf"

--- a/src/main/scala/org/globalforestwatch/summarystats/SummaryCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/SummaryCommand.scala
@@ -106,8 +106,8 @@ trait SummaryCommand {
 
   val noOutputPathSuffixOpt: Opts[Boolean] = Opts.flag("no_output_path_suffix", help = "Do not autogenerate output path suffix at runtime").orFalse
 
-  val defaultOptions: Opts[(String, NonEmptyList[String], String, Boolean, Boolean, Boolean)] =
-    (featureTypeOpt, featuresOpt, outputOpt, splitFeatures, noOutputPathSuffixOpt, gfwPro).tupled
+  val defaultOptions: Opts[(String, NonEmptyList[String], String, Boolean, Boolean)] =
+    (featureTypeOpt, featuresOpt, outputOpt, splitFeatures, noOutputPathSuffixOpt ).tupled
   val fireAlertOptions: Opts[(String, NonEmptyList[String])] =
     (fireAlertTypeOpt, fireAlertSourceOpt).tupled
 

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
@@ -41,8 +41,6 @@ object ForestChangeDiagnosticCommand extends SummaryCommand {
         "glad" -> defaultFilter._3
       )
 
-      GfwConfig.setProFlag(default._6)
-
       runAnalysis(ForestChangeDiagnosticAnalysis.name, default._1, default._2, kwargs)
 
     }

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
@@ -55,7 +55,6 @@ object GfwProDashboardCommand extends SummaryCommand {
         "admin2" -> gadmFilter._6,
       )
 
-      GfwConfig.setProFlag(default._6)
       runAnalysis(GfwProDashboardAnalysis.name, default._1, default._2, kwargs)
 
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.7.2"
+version in ThisBuild := "1.7.3"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
currently we're using `--gfwpro` flag to control which rasters get read for Pro and which tags we're using. The mechanism used however does not work on EMR because Spark does not properly serialize the state of the global variable and ends up running with default value `flagship`. Making the current mechanism work would require a pretty large refactor so the next best is the ENV variable. 

## What is the new behavior?
Using `GFW_FEATURE_FLAG` = `pro`, `flagship`, or null with `pro` being default behavior.

## Does this introduce a breaking change?
- [x] Yes
- [ ] No

for the moment pro is the default configuration, this may not be desirable in the long-run, but either way this now needs to be considered by flagship run or changed on further discussion.