### PR TITLE
Fix missing 2020 in ForestChangeDiagnostic yearly summaries

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticDataLossYearly.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticDataLossYearly.scala
@@ -5,17 +5,13 @@ import frameless.Injection
 import scala.collection.immutable.SortedMap
 import io.circe.syntax._
 import io.circe.parser.decode
+import spire.algebra.Semigroup
 
-case class ForestChangeDiagnosticDataLossYearly(value: SortedMap[Int, Double]) extends ForestChangeDiagnosticDataParser[ForestChangeDiagnosticDataLossYearly] {
-  def merge(
-             other: ForestChangeDiagnosticDataLossYearly
-           ): ForestChangeDiagnosticDataLossYearly = {
+case class ForestChangeDiagnosticDataLossYearly(value: SortedMap[Int, Double])
+  extends ForestChangeDiagnosticDataParser[ForestChangeDiagnosticDataLossYearly] {
 
-    ForestChangeDiagnosticDataLossYearly(value ++ other.value.map {
-      case (key, otherValue) =>
-        key ->
-          (value.getOrElse(key, 0.0) + otherValue)
-    })
+  def merge(other: ForestChangeDiagnosticDataLossYearly): ForestChangeDiagnosticDataLossYearly = {
+    ForestChangeDiagnosticDataLossYearly(Semigroup[SortedMap[Int, Double]].combine(value, other.value))
   }
 
   def round: SortedMap[Int, Double] = this.value.map { case (key, value) => key -> this.round(value) }
@@ -52,7 +48,8 @@ object ForestChangeDiagnosticDataLossYearly {
         2016 -> 0,
         2017 -> 0,
         2018 -> 0,
-        2019 -> 0
+        2019 -> 0,
+        2020 -> 0
       )
     )
 

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticDataValueYearly.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticDataValueYearly.scala
@@ -5,20 +5,13 @@ import frameless.Injection
 import scala.collection.immutable.SortedMap
 import io.circe.syntax._
 import io.circe.parser.decode
+import spire.algebra.Semigroup
 
 case class ForestChangeDiagnosticDataValueYearly(value: SortedMap[Int, Double])
-  extends ForestChangeDiagnosticDataParser[
-    ForestChangeDiagnosticDataValueYearly
-  ] {
-  def merge(
-             other: ForestChangeDiagnosticDataValueYearly
-           ): ForestChangeDiagnosticDataValueYearly = {
+  extends ForestChangeDiagnosticDataParser[ForestChangeDiagnosticDataValueYearly] {
 
-    ForestChangeDiagnosticDataValueYearly(value ++ other.value.map {
-      case (key, otherValue) =>
-        key ->
-          (value.getOrElse(key, 0.0) + otherValue)
-    })
+  def merge(other: ForestChangeDiagnosticDataValueYearly): ForestChangeDiagnosticDataValueYearly = {
+    ForestChangeDiagnosticDataValueYearly(Semigroup[SortedMap[Int, Double]].combine(value, other.value))
   }
 
   def toJson: String = {
@@ -77,7 +70,8 @@ object ForestChangeDiagnosticDataValueYearly {
         2016 -> 0,
         2017 -> 0,
         2018 -> 0,
-        2019 -> 0
+        2019 -> 0,
+        2020 -> 0
       )
     )
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Tree cover loss values for 2020 are not present in ForestChangeDiagnostic output


## What is the new behavior?
2020 TCL values are included
## Does this introduce a breaking change?

- [ ] Yes
- [x] No