### PR TITLE
ForestChangeDiagnostic uses spatial index

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
@@ -1,284 +1,298 @@
-package org.globalforestwatch.summarystats.forest_change_diagnostic
+ package org.globalforestwatch.summarystats.forest_change_diagnostic
 
-import cats.data.NonEmptyList
-import cats.data.Validated.{Invalid, Valid}
-import cats.syntax._
+ import cats.data.NonEmptyList
+ import cats.data.Validated.{Invalid, Valid}
+ import cats.syntax._
 
-import java.util
-import scala.collection.JavaConverters._
-import scala.collection.immutable.SortedMap
-import geotrellis.vector.{Feature, Geometry}
-import com.vividsolutions.jts.geom.{Geometry => GeoSparkGeometry}
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.SparkSession
-import org.datasyslab.geospark.spatialRDD.SpatialRDD
-import org.globalforestwatch.features._
-import org.globalforestwatch.grids.GridId.pointGridId
-import org.globalforestwatch.summarystats.{JobError, MultiError, SummaryAnalysis, ValidatedRow}
-import org.globalforestwatch.util.SpatialJoinRDD
-import org.globalforestwatch.util.ImplicitGeometryConverter._
-import org.globalforestwatch.util.Util.getAnyMapValue
-import org.apache.spark.storage.StorageLevel
+ import java.util
+ import scala.collection.JavaConverters._
+ import scala.collection.immutable.SortedMap
+ import geotrellis.vector.{Feature, Geometry}
+ import com.vividsolutions.jts.geom.{Geometry => GeoSparkGeometry}
+ import org.apache.spark.rdd.RDD
+ import org.apache.spark.sql.SparkSession
+ import org.datasyslab.geospark.spatialRDD.SpatialRDD
+ import org.globalforestwatch.features.{CombinedFeatureId, FeatureId, FireAlertRDD, GadmFeatureId, GfwProFeature, GfwProFeatureId, GridId, WdpaFeatureId}
+ import org.globalforestwatch.grids.GridId.pointGridId
+ import org.globalforestwatch.summarystats.{JobError, MultiError, SummaryAnalysis, ValidatedRow}
+ import org.globalforestwatch.util.SpatialJoinRDD
+ import org.globalforestwatch.util.ImplicitGeometryConverter._
+ import org.globalforestwatch.util.Util.getAnyMapValue
+ import org.apache.spark.storage.StorageLevel
 
-object ForestChangeDiagnosticAnalysis extends SummaryAnalysis {
+ object ForestChangeDiagnosticAnalysis extends SummaryAnalysis {
 
-  val name = "forest_change_diagnostic"
+   val name = "forest_change_diagnostic"
 
-  def apply(
-    mainRDD: RDD[Feature[Geometry, FeatureId]],
-    featureType: String,
-    intermediateListSource: Option[NonEmptyList[String]],
-    fireAlertRDD: SpatialRDD[GeoSparkGeometry],
-    kwargs: Map[String, Any]
-  )(implicit spark: SparkSession): Unit = {
+   def apply(
+     mainRDD: RDD[Feature[Geometry, FeatureId]],
+     featureType: String,
+     intermediateListSource: Option[NonEmptyList[String]],
+     fireAlertRDD: SpatialRDD[GeoSparkGeometry],
+     spark: SparkSession,
+     kwargs: Map[String, Any]
+   ): Unit = {
 
-    val runOutputUrl: String = getOutputUrl(kwargs)
+     val runOutputUrl: String = getOutputUrl(kwargs)
 
-    mainRDD.persist(StorageLevel.MEMORY_AND_DISK_2)
+     mainRDD.persist(StorageLevel.MEMORY_AND_DISK_2)
 
-    // For standard GFW Pro Feature IDs we create a Grid Filter
-    // This will allow us to only process those parts of the dissolved list geometry which were updated
-    // When using other Feature IDs such as WDPA or GADM,
-    // there will be no intermediate results and this part will be ignored
-    val gridFilter: List[String] =
-      mainRDD
-        .filter { feature: Feature[Geometry, FeatureId] =>
-          feature.data match {
-            case gfwproId: GfwProFeatureId => gfwproId.locationId == -2
-            case _                         => false
-          }
-        }
-        .map(f => pointGridId(f.geom.getCentroid, 1))
-        .collect
-        .toList
 
-    val featureRDD: RDD[Feature[Geometry, FeatureId]] =
-      toFeatureRdd(mainRDD, gridFilter, intermediateListSource.isDefined)
+     // For standard GFW Pro Feature IDs we create a Grid Filter
+     // This will allow us to only process those parts of the dissolved list geometry which were updated
+     // When using other Feature IDs such as WDPA or GADM,
+     // there will be no intermediate results and this part will be ignored
+     val gridFilter: List[String] =
+     mainRDD
+       .filter { feature: Feature[Geometry, FeatureId] =>
+         feature.data match {
+           case gfwproId: GfwProFeatureId => gfwproId.locationId == -2
+           case _ => false
+         }
+       }
+       .map(f => pointGridId(f.geom.getCentroid, 1))
+       .collect
+         .toList
 
-    featureRDD.persist(StorageLevel.MEMORY_AND_DISK_2)
+     val featureRDD: RDD[Feature[Geometry, FeatureId]] =
+       toFeatureRdd(mainRDD, gridFilter, intermediateListSource.isDefined)
 
-    val summaryRDD: RDD[(FeatureId, ValidatedRow[ForestChangeDiagnosticSummary])] =
-      ForestChangeDiagnosticRDD(featureRDD, ForestChangeDiagnosticGrid.blockTileGrid, kwargs)
+     featureRDD.persist(StorageLevel.MEMORY_AND_DISK_2)
 
-   // TODO: why are we doing two left joins here (one in fireStats and one in dataRDD?
-    val fireCount: RDD[(FeatureId, ForestChangeDiagnosticDataLossYearly)] =
-      ForestChangeDiagnosticAnalysis.fireStats(featureRDD, fireAlertRDD, spark)
+     val summaryRDD: RDD[(FeatureId, ValidatedRow[ForestChangeDiagnosticSummary])] =
+       ForestChangeDiagnosticRDD(
+         featureRDD,
+         ForestChangeDiagnosticGrid.blockTileGrid,
+         kwargs)
 
-    val dataRDD: RDD[(FeatureId, ValidatedRow[ForestChangeDiagnosticData])] = {
-      summaryRDD
-        .mapValues { validated => validated.map(_.toForestChangeDiagnosticData().withUpdatedCommodityRisk()) }
-        .leftOuterJoin(fireCount)
-        .mapValues { case (validated, fire) =>
-          // Fire results are discarded if joined to error summary
-          validated.map { data =>
-            data.copy(
-              commodity_threat_fires = fire.getOrElse(ForestChangeDiagnosticDataLossYearly.empty)
-            )
-          }
-        }
-    }
+     val fireCount: RDD[(FeatureId, ForestChangeDiagnosticDataLossYearly)] =
+       ForestChangeDiagnosticAnalysis.fireStats(featureRDD, fireAlertRDD, spark)
 
-    dataRDD.persist(StorageLevel.MEMORY_AND_DISK_2)
+     val dataRDD: RDD[(FeatureId, ValidatedRow[ForestChangeDiagnosticData])] = {
+       summaryRDD
+         .mapValues{ validated => validated.map(_.toForestChangeDiagnosticData().withUpdatedCommodityRisk()) }
+         .leftOuterJoin(fireCount)
+         .mapValues {
+           case (validated, fire) =>
+             // Fire results are discarded if joined to error summary
+             validated.map { data =>
+               data.copy(
+                 commodity_threat_fires = fire.getOrElse(ForestChangeDiagnosticDataLossYearly.empty)
+               )
+             }
+         }
+     }
 
-    val finalRDD =
-      if (featureType == "gfwpro")
-        combineIntermediateList(dataRDD, gridFilter, runOutputUrl, spark, kwargs)
-      else dataRDD
+     dataRDD.persist(StorageLevel.MEMORY_AND_DISK_2)
 
-    val summaryDF = ForestChangeDiagnosticDF.getFeatureDataFrame(finalRDD, spark)
+     val finalRDD =
+       if (featureType == "gfwpro")
+         combineIntermediateList(
+           dataRDD,
+           gridFilter,
+           runOutputUrl,
+           spark,
+           kwargs)
+       else dataRDD
 
-    ForestChangeDiagnosticExport.export(featureType, summaryDF, runOutputUrl, kwargs)
-  }
+     val summaryDF = ForestChangeDiagnosticDF.getFeatureDataFrame(finalRDD, spark)
 
-  /** GFW Pro hand of a input features in a TSV file TSV file contains the individual list items, the merged list geometry and the
-    * geometric difference from the current merged list geometry and the former one. Individual list items have location IDs >= 0 Merged
-    * list geometry has location ID -1 Geometric difference to previous version has location ID -2
-    *
-    * Merged list and geometric difference may or may be not present. If geometric difference is present, we only need to process chunks
-    * of the merged list which fall into the same grid cells as the geometric difference. Later in the analysis we will then read cached
-    * values for the remaining chunks and use them to aggregate list level results.
-    */
-  private def toFeatureRdd(
-    mainRDD: RDD[Feature[Geometry, FeatureId]],
-    gridFilter: List[String],
-    useFilter: Boolean
-  ): RDD[Feature[Geometry, FeatureId]] = {
-    mainRDD
-      .filter { feature: Feature[Geometry, FeatureId] =>
-        feature.data match {
-          case _: WdpaFeatureId                                       => true
-          case _: GadmFeatureId                                       => true
-          case gfwproId: GfwProFeatureId if gfwproId.locationId >= 0  => true
-          case gfwproId: GfwProFeatureId if gfwproId.locationId == -1 =>
-            // If no geometric difference or intermediate result table is present process entire merged list geometry
-            if (gridFilter.isEmpty || !useFilter) true
-            // Otherwise only process chunks which fall into the same grid cells as the geometric difference
-            else gridFilter.contains(pointGridId(feature.geom.getCentroid, 1))
-          case _ => false
-        }
-      }
-      .map { feature: Feature[Geometry, FeatureId] =>
-        feature.data match {
-          case _: WdpaFeatureId                                      => feature
-          case _: GadmFeatureId                                      => feature
-          case gfwproId: GfwProFeatureId if gfwproId.locationId >= 0 => feature
-          case _ =>
-            val grid = pointGridId(feature.geom.getCentroid, 1)
-            // For merged list, update data to contain the Combine Feature ID including the Grid ID
-            Feature(feature.geom, CombinedFeatureId(feature.data, GridId(grid)))
-        }
-      }
-  }
+     ForestChangeDiagnosticExport.export(
+       featureType,
+       summaryDF,
+       runOutputUrl,
+       kwargs)
+   }
 
-  def combineIntermediateList(
-    dataRDD: RDD[(FeatureId, ValidatedRow[ForestChangeDiagnosticData])],
-    gridFilter: List[String],
-    outputUrl: String,
-    spark: SparkSession,
-    kwargs: Map[String, Any]
-  ): RDD[(FeatureId, ValidatedRow[ForestChangeDiagnosticData])] = {
+   /**
+     * GFW Pro hand of a input features in a TSV file
+     * TSV file contains the individual list items, the merged list geometry and the geometric difference from the current merged list geometry and the former one.
+     * Individual list items have location IDs >= 0
+     * Merged list geometry has location ID -1
+     * Geometric difference to previous version has location ID -2
+     *
+     * Merged list and geometric difference may or may be not present.
+     * If geometric difference is present, we only need to process chunks of the merged list which fall into the same grid cells as the geometric difference.
+     * Later in the analysis we will then read cached values for the remaining chunks and use them to aggregate list level results.
+     * */
+   private def toFeatureRdd(
+     mainRDD: RDD[Feature[Geometry, FeatureId]],
+     gridFilter: List[String],
+     useFilter: Boolean
+   ): RDD[Feature[Geometry, FeatureId]] = {
 
-    val intermediateListSource = getAnyMapValue[Option[NonEmptyList[String]]](
-      kwargs,
-      "intermediateListSource"
-    )
+     val featureRDD: RDD[Feature[Geometry, FeatureId]] = mainRDD
+       .filter { feature: Feature[Geometry, FeatureId] =>
+         feature.data match {
+           case _: WdpaFeatureId => true
+           case _: GadmFeatureId => true
+           case gfwproId: GfwProFeatureId if gfwproId.locationId >= 0 => true
+           case gfwproId: GfwProFeatureId if gfwproId.locationId == -1 =>
+             // If no geometric difference or intermediate result table is present process entire merged list geometry
+             if (gridFilter.isEmpty || !useFilter) true
+             // Otherwise only process chunks which fall into the same grid cells as the geometric difference
+             else gridFilter.contains(pointGridId(feature.geom.getCentroid, 1))
+           case _ => false
+         }
 
-    // Get merged list RDD
-    val listRDD = dataRDD.filter {
-      _._1 match {
-        case _: CombinedFeatureId => true
-        case _                    => false
-      }
-    }
+       }
+       .map { feature: Feature[Geometry, FeatureId] =>
+         feature.data match {
+           case _: WdpaFeatureId => feature
+           case _: GadmFeatureId => feature
+           case gfwproId: GfwProFeatureId if gfwproId.locationId >= 0 => feature
+           case _ =>
+             val grid = pointGridId(feature.geom.getCentroid, 1)
+             // For merged list, update data to contain the Combine Feature ID including the Grid ID
+             Feature(feature.geom, CombinedFeatureId(feature.data, GridId(grid)))
+         }
+       }
 
-    // Get row RDD
-    val rowRDD = dataRDD.filter {
-      _._1 match {
-        case _: CombinedFeatureId => false
-        case _                    => true
-      }
-    }
+     featureRDD
 
-    // combine filtered List with filtered intermediate results
-    val combinedListRDD = {
-      if (intermediateListSource.isDefined) {
-        ForestChangeDiagnosticDF
-          .readIntermidateRDD(intermediateListSource.get, spark)
-          .filter {
-            _._1 match {
-              case combinedId: CombinedFeatureId =>
-                !gridFilter.contains(combinedId.featureId2.toString)
-              case _ => false
-            }
-          }
-          .union(listRDD)
-      } else listRDD
-    }
+   }
 
-    // EXPORT new intermediate results
-    val combinedListDF = ForestChangeDiagnosticDF.getGridFeatureDataFrame(combinedListRDD, spark)
+   def combineIntermediateList(
+     dataRDD: RDD[(FeatureId, ValidatedRow[ForestChangeDiagnosticData])],
+     gridFilter: List[String],
+     outputUrl: String,
+     spark: SparkSession,
+     kwargs: Map[String, Any]
+   ): RDD[(FeatureId, ValidatedRow[ForestChangeDiagnosticData])] = {
 
-    ForestChangeDiagnosticExport.export(
-      "intermediate",
-      combinedListDF,
-      outputUrl,
-      kwargs
-    )
+     val intermediateListSource = getAnyMapValue[Option[NonEmptyList[String]]](
+       kwargs,
+       "intermediateListSource"
+     )
 
-    // Reduce by feature ID and update commodity risk
-    val updatedListRDD = combinedListRDD
-      .map { case (id, data) =>
-        id match {
-          case combinedId: CombinedFeatureId =>
-            (combinedId.featureId1, data)
-        }
-      }
-      .reduceByKey(_ combine _)
-      .mapValues { _.map(_.withUpdatedCommodityRisk()) }
+     // Get merged list RDD
+     val listRDD = dataRDD.filter { _._1 match {
+       case _: CombinedFeatureId => true
+       case _ => false
+     }}
 
-    // Merge with row RDD
-    rowRDD.union(updatedListRDD)
-  }
+     // Get row RDD
+     val rowRDD = dataRDD.filter { _._1 match {
+       case _: CombinedFeatureId => false
+       case _ => true
+     }}
 
-  def fireStats(
-    featureRDD: RDD[Feature[Geometry, FeatureId]],
-    fireAlertRDD: SpatialRDD[GeoSparkGeometry],
-    spark: SparkSession
-  ): RDD[(FeatureId, ForestChangeDiagnosticDataLossYearly)] = {
-    // Convert FeatureRDD to SpatialRDD
-    val polyRDD = featureRDD.map { feature =>
-      // Implicitly convert to GeoSparkGeometry
-      val geom: GeoSparkGeometry = feature.geom
-      geom.setUserData(feature.data)
-      geom
-    }
-    val spatialFeatureRDD = new SpatialRDD[GeoSparkGeometry]
-    spatialFeatureRDD.rawSpatialRDD = polyRDD.toJavaRDD()
-    spatialFeatureRDD.fieldNames = seqAsJavaList(List("FeatureId"))
-    spatialFeatureRDD.analyze()
+     // combine filtered List with filtered intermediate results
+     val combinedListRDD = {
+       if (intermediateListSource.isDefined) {
+         ForestChangeDiagnosticDF.readIntermidateRDD(intermediateListSource.get, spark)
+           .filter { _._1 match {
+             case combinedId: CombinedFeatureId =>
+               !gridFilter.contains(combinedId.featureId2.toString)
+             case _ => false
+           }}
+           .union(listRDD)
+       } else listRDD
+     }
 
-    val joinedRDD =
-      SpatialJoinRDD.spatialjoin(
-        spatialFeatureRDD,
-        fireAlertRDD,
-        usingIndex = true
-      )
+     // EXPORT new intermediate results
+     val combinedListDF = ForestChangeDiagnosticDF.getGridFeatureDataFrame(combinedListRDD, spark)
 
-    joinedRDD.rdd
-      .map { case (poly, points) =>
-        toForestChangeDiagnosticFireData(poly, points)
-      }
-      .reduceByKey(_ merge _)
-      .mapValues { fires =>
-        aggregateFireData(fires)
-      }
-  }
+     ForestChangeDiagnosticExport.export(
+       "intermediate",
+       combinedListDF,
+       outputUrl,
+       kwargs
+     )
 
-  private def toForestChangeDiagnosticFireData(
-    poly: GeoSparkGeometry,
-    points: util.HashSet[GeoSparkGeometry]
-  ): (FeatureId, ForestChangeDiagnosticDataLossYearly) = {
-    (
-      poly.getUserData.asInstanceOf[FeatureId], {
-        val fireCount =
-          points.asScala.toList.foldLeft(SortedMap[Int, Double]()) { (z: SortedMap[Int, Double], point) =>
-            {
-              // extract year from acq_date column
-              val year = point.getUserData
-                .asInstanceOf[String]
-                .split("\t")(2)
-                .substring(0, 4)
-                .toInt
-              val count = z.getOrElse(year, 0.0) + 1.0
-              z.updated(year, count)
-            }
-          }
+     // Reduce by feature ID and update commodity risk
+     val updatedListRDD = combinedListRDD
+       .map {
+         case (id, data) =>
+           id match {
+             case combinedId: CombinedFeatureId =>
+               (combinedId.featureId1, data)
+           }
+       }
+       .reduceByKey(_ combine _)
+       .mapValues { _.map(_.withUpdatedCommodityRisk()) }
 
-        ForestChangeDiagnosticDataLossYearly.prefilled
-          .merge(ForestChangeDiagnosticDataLossYearly(fireCount))
-      }
-    )
-  }
+     // Merge with row RDD
+     rowRDD.union(updatedListRDD)
+   }
 
-  private def aggregateFireData(
-    fires: ForestChangeDiagnosticDataLossYearly
-  ): ForestChangeDiagnosticDataLossYearly = {
-    val minFireYear = fires.value.keysIterator.min
-    val maxFireYear = fires.value.keysIterator.max
-    val years: List[Int] = List.range(minFireYear + 1, maxFireYear + 1)
+   def fireStats(
+     featureRDD: RDD[Feature[Geometry, FeatureId]],
+     fireAlertRDD: SpatialRDD[GeoSparkGeometry],
+     spark: SparkSession
+   ): RDD[(FeatureId, ForestChangeDiagnosticDataLossYearly)] = {
+     // Convert FeatureRDD to SpatialRDD
+     val polyRDD = featureRDD.map { feature =>
+       // Implicitly convert to GeoSparkGeometry
+       val geom: GeoSparkGeometry = feature.geom
+       geom.setUserData(feature.data)
+       geom
+     }
+     val spatialFeatureRDD = new SpatialRDD[GeoSparkGeometry]
+     spatialFeatureRDD.rawSpatialRDD = polyRDD.toJavaRDD()
+     spatialFeatureRDD.fieldNames = seqAsJavaList(List("FeatureId"))
+     spatialFeatureRDD.analyze()
 
-    ForestChangeDiagnosticDataLossYearly(
-      SortedMap(
-        years.map(year =>
-          (
-            year, {
-              val thisYearFireCount: Double = fires.value.getOrElse(year, 0)
-              val lastYearFireCount: Double = fires.value.getOrElse(year - 1, 0)
-              (thisYearFireCount + lastYearFireCount) / 2
-            }
-          )
-        ): _*
-      )
-    )
-  }
-}
+     val joinedRDD =
+       SpatialJoinRDD.spatialjoin(
+         spatialFeatureRDD,
+         fireAlertRDD,
+         usingIndex = true
+       )
+
+     joinedRDD.rdd
+       .map {
+         case (poly, points) =>
+           toForestChangeDiagnosticFireData(poly, points)
+       }
+       .reduceByKey(_ merge _)
+       .mapValues { fires =>
+         aggregateFireData(fires)
+       }
+   }
+
+   private def toForestChangeDiagnosticFireData(
+                                                 poly: GeoSparkGeometry,
+                                                 points: util.HashSet[GeoSparkGeometry]
+                                               ): (FeatureId, ForestChangeDiagnosticDataLossYearly) = {
+     (poly.getUserData.asInstanceOf[FeatureId], {
+       val fireCount =
+         points.asScala.toList.foldLeft(SortedMap[Int, Double]()) {
+           (z: SortedMap[Int, Double], point) => {
+             // extract year from acq_date column
+             val year = point.getUserData
+               .asInstanceOf[String]
+               .split("\t")(2)
+               .substring(0, 4)
+               .toInt
+             val count = z.getOrElse(year, 0.0) + 1.0
+             z.updated(year, count)
+           }
+         }
+
+       ForestChangeDiagnosticDataLossYearly.prefilled
+         .merge(ForestChangeDiagnosticDataLossYearly(fireCount))
+     })
+   }
+
+   private def aggregateFireData(
+                                  fires: ForestChangeDiagnosticDataLossYearly
+                                ): ForestChangeDiagnosticDataLossYearly = {
+     val minFireYear = fires.value.keysIterator.min
+     val maxFireYear = fires.value.keysIterator.max
+     val years: List[Int] = List.range(minFireYear + 1, maxFireYear + 1)
+
+     ForestChangeDiagnosticDataLossYearly(
+       SortedMap(
+         years.map(
+           year =>
+             (year, {
+               val thisYearFireCount: Double = fires.value.getOrElse(year, 0)
+               val lastYearFireCount: Double = fires.value.getOrElse(year - 1, 0)
+               (thisYearFireCount + lastYearFireCount) / 2
+             })
+         ): _*
+       )
+     )
+   }
+ }

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
@@ -102,6 +102,10 @@
        summaryDF,
        runOutputUrl,
        kwargs)
+
+      mainRDD.unpersist()
+      featureRDD.unpersist()
+      dataRDD.unpersist()
    }
 
    /**

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
@@ -39,10 +39,10 @@ object ForestChangeDiagnosticCommand extends SummaryCommand with LazyLogging {
       if (! default.splitFeatures) logger.warn("Forcing splitFeatures = true")
       val featureFilter = FeatureFilter.fromOptions(default.featureType, filterOptions)
 
-      runAnalysis { spark =>
+      runAnalysis { implicit spark =>
         val featureRDD = FeatureRDD(default.featureUris, default.featureType, featureFilter, splitFeatures = true, spark)
         val fireAlertRDD = FireAlertRDD(spark, fireAlert.alertType, fireAlert.alertSource, FeatureFilter.empty)
-        ForestChangeDiagnosticAnalysis(featureRDD, default.featureType, intermediateListSource, fireAlertRDD, spark, kwargs)
+        ForestChangeDiagnosticAnalysis(featureRDD, default.featureType, intermediateListSource, fireAlertRDD, kwargs)
       }
     }
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.7.5"
+version in ThisBuild := "1.7.6"


### PR DESCRIPTION

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): 


## What is the current behavior?
The use use of spatial index when joining fire events point dataset to input feature list in ForestChangeDiagnostics was disable because it caused a non-obvious failure in assembling the R-Tree. Unfortunately the exact dataset is lost to time. 


## What is the new behavior?
However, not using the spatial index here results in unacceptable performance on the benchmark dataset: `palm_oil_mills.tsv`. The decision here is to flip the switch back on and be prepared to deal with earlier failure directly.
At the moment being able to run the benchmark dataset with expected performance is primary concern 🐬 .

This PR also incidentally uses on-disk caching for the datasets in FCD that are used more than once. These will be cleaned up when the job finishes. This should help the job performance overall. 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Maybe
