### PR TITLE
Repartition instead of coalesce on export

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticExport.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticExport.scala
@@ -36,7 +36,7 @@ object ForestChangeDiagnosticExport extends SummaryExport {
                             kwargs: Map[String, Any]): Unit = {
 
     summaryDF
-      .coalesce(1)
+      .repartition(1)
       .write
       .options(csvOptions)
       .csv(path = outputUrl + "/final")
@@ -47,7 +47,7 @@ object ForestChangeDiagnosticExport extends SummaryExport {
                                      outputUrl: String): Unit = {
 
     intermediateListDF
-      .coalesce(1)
+      .repartition(1)
       .write
       .options(csvOptions)
       .csv(path = outputUrl + "/intermediate")

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardExport.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardExport.scala
@@ -20,7 +20,7 @@ object GfwProDashboardExport extends SummaryExport {
                                       kwargs: Map[String, Any]): Unit = {
 
     summaryDF
-      .coalesce(1)
+      .repartition(1)
       .write
       .options(csvOptions)
       .csv(path = outputUrl + "/final")


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
`coalesce(1)` sometimes hangs on large jobs,


## What is the new behavior?
 `repartition(1)` allows shuffle to happen, fixing the apparent hangs


## Does this introduce a breaking change?

- [ ] Yes
- [x] No
