### PR TITLE
Fix side location conflict

### DIFF
--- a/src/main/scala/org/globalforestwatch/features/SpatialFeatureDF.scala
+++ b/src/main/scala/org/globalforestwatch/features/SpatialFeatureDF.scala
@@ -48,9 +48,11 @@ object SpatialFeatureDF {
       FeatureDF(input, featureObj, filters, spark, delimiter)
     val emptyPolygonWKB = "0106000020E610000000000000"
 
+    // ST_PrecisionReduce may create invalid geometry if it contains a "sliver" that is below the precision threshold
+    // ST_Buffer(0) fixes these invalid geometries
     featureDF
       .selectExpr(
-        s"ST_PrecisionReduce(ST_GeomFromWKB(${wkbField}), 11) AS polyshape",
+        s"ST_Buffer(ST_PrecisionReduce(ST_GeomFromWKB(${wkbField}), 11), 0) AS polyshape",
         s"struct(${featureObj.featureIdExpr}) as featureId"
       )
       .where(s"${wkbField} != '${emptyPolygonWKB}'")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.7.6"
+version in ThisBuild := "1.7.7"


### PR DESCRIPTION
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Sometimes reading the input features fails with `com.vividsolutions.jts.geom.TopologyException: side location conflict`
This appears to be because the precision reduction turns tiny pockets and slivers into invalid geometries.
This issue is handled better by later version of JTS. However, it's not possible to upgrade to them right now.

## What is the new behavior?
We apply `ST_Buffer(0)` to fix the invalid geometries after precision reduction.
This is not ideal because because one wonders if it may introduce some other changes, but is standard fix to these types of issues until JTS version can be updated.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
