### PR TITLE
Only compute commodity threat to year 2019

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
@@ -250,7 +250,7 @@
        }
        .reduceByKey(_ merge _)
        .mapValues { fires =>
-         aggregateFireData(fires)
+         aggregateFireData(fires).limitToMaxYear(2019)
        }
    }
 

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticData.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticData.scala
@@ -157,12 +157,13 @@ case class ForestChangeDiagnosticData(
   }
 
   def withUpdatedCommodityRisk(): ForestChangeDiagnosticData = {
-    val minLossYear =
-      ForestChangeDiagnosticDataLossYearly.prefilled.value.keysIterator.min
 
-    val maxLossYear =
-      ForestChangeDiagnosticDataLossYearly.prefilled.value.keysIterator.max
-
+    /* Exclude the last year, limit data to 2019 to sync with palm risk tool:
+    commodity_threat_deforestation, commodity_threat_peat, commodity_threat_protected_areas use year n and year n-1.
+    Including information from the current year would under-represent these values as it's in progress.
+    */
+    val minLossYear = ForestChangeDiagnosticDataLossYearly.prefilled.value.keys.min
+    val maxLossYear = 2019
     val years: List[Int] = List.range(minLossYear + 1, maxLossYear + 1)
 
     val forestValueIndicator: ForestChangeDiagnosticDataValueYearly =

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticDataLossYearly.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticDataLossYearly.scala
@@ -16,6 +16,10 @@ case class ForestChangeDiagnosticDataLossYearly(value: SortedMap[Int, Double])
 
   def round: SortedMap[Int, Double] = this.value.map { case (key, value) => key -> this.round(value) }
 
+  def limitToMaxYear(maxYear: Int): ForestChangeDiagnosticDataLossYearly = {
+    ForestChangeDiagnosticDataLossYearly(value.filterKeys{ year => year <= maxYear })
+  }
+
   def toJson: String = {
     this.round.asJson.noSpaces
   }


### PR DESCRIPTION
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Commodity threat columns are updated to 2020

## What is the new behavior?
They are limited to 2019

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


```python
from list_utils import *
idn_32 = FCD.read_output("s3://gfwpro-geotrellis-qa/qa/results/.../forest_change_diagnostic_211013_162342")
idn_32['commodity_threat_peat'].reset_index()['year'].unique()
```

```
array(['2002', '2003', '2004', '2005', '2006', '2007', '2008', '2009',
       '2010', '2011', '2012', '2013', '2014', '2015', '2016', '2017',
       '2018', '2019'], dtype=object)
```
![Screen Shot 2021-10-14 at 12 54 36 PM](https://user-images.githubusercontent.com/1158084/137362414-ed83c097-83c4-4eab-af50-5106380abc4a.png)


