### PR TITLE
Fix lock TCL on soy to 2019

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
@@ -76,7 +76,8 @@
              // Fire results are discarded if joined to error summary
              validated.map { data =>
                data.copy(
-                 commodity_threat_fires = fire.getOrElse(ForestChangeDiagnosticDataLossYearly.empty)
+                 commodity_threat_fires = fire.getOrElse(ForestChangeDiagnosticDataLossYearly.empty),
+                 tree_cover_loss_soy_yearly = data.tree_cover_loss_soy_yearly.limitToMaxYear(2019)
                )
              }
          }


### PR DESCRIPTION
## Pull request checklist


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Soy is planted and harvested later in the year. The 2020 TCL is 2019 harvest.
The methodology is to lock the output to 2019 until available data is updated instead of offsetting the year.
Using demo org 1, list 187 the old output is:

<img width="458" alt="Screen Shot 2021-10-18 at 4 24 25 PM" src="https://user-images.githubusercontent.com/1158084/137801559-ad860a2c-0014-4af2-a94c-227cfcb4536a.png">


## What is the new behavior?
We report soy TCL for 2020

<img width="451" alt="Screen Shot 2021-10-18 at 4 24 37 PM" src="https://user-images.githubusercontent.com/1158084/137801580-eda399f4-a138-4ef8-9bcd-8b9b82fd9d97.png">



## Does this introduce a breaking change?

- [ ] Yes
- [x] No
