### PR TITLE
Fix GLAD alerts Coverage in dashboard

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardAnalysis.scala
@@ -192,7 +192,7 @@ object GfwProDashboardAnalysis extends SummaryAnalysis {
           // We need to convert the Map to a List in order to correctly flatmap the data
           summary.stats.toList.map {
             case (dataGroup, data) =>
-              (featureId, dataGroup.toGfwProDashboardData(data.alertCount, data.totalArea))
+              (featureId, dataGroup.toGfwProDashboardData(data.alertCount, data.treeCoverExtentArea))
           }
       }
   }

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardData.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardData.scala
@@ -9,11 +9,17 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
   * Note: This case class contains mutable values
   */
 case class GfwProDashboardData(
+  /** Location intersects GLAD Alert tiles, GLAD alerts are possible */
   glad_alerts_coverage: Boolean,
+  /** How many hacters of location geometry had tree cover extent > 30%  in 2000 */
   tree_cover_extent_total: ForestChangeDiagnosticDataDouble,
+  /** GLAD alert count within location geometry grouped by day */
   glad_alerts_daily: GfwProDashboardDataDateCount,
+  /** GLAD alert count within location geometry grouped by ISO year-week */
   glad_alerts_weekly: GfwProDashboardDataDateCount,
+  /** GLAD alert count within location geometry grouped by year-month */
   glad_alerts_monthly: GfwProDashboardDataDateCount,
+  /** VIIRS alerts for location geometry grouped by day */
   viirs_alerts_daily: GfwProDashboardDataDateCount,
 ) {
 

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardDataDateCount.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardDataDateCount.scala
@@ -5,6 +5,8 @@ import io.circe.syntax._
 import java.util.Calendar
 import scala.collection.immutable.SortedMap
 import frameless.Injection
+import cats.syntax._
+import cats.implicits._
 import java.time.LocalDate
 import java.time.format._
 import java.time.temporal._
@@ -15,10 +17,7 @@ import _root_.com.amazonaws.thirdparty.joda.time.DateTime
 case class GfwProDashboardDataDateCount(value: SortedMap[String, Int]) {
 
   def merge(other: GfwProDashboardDataDateCount): GfwProDashboardDataDateCount = {
-    GfwProDashboardDataDateCount(value ++ other.value.map {
-      case (key, otherValue) =>
-        key -> (value.getOrElse(key, 0) + otherValue)
-    })
+    GfwProDashboardDataDateCount(value combine other.value)
   }
 
   def toJson: String = this.value.asJson.noSpaces

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawData.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawData.scala
@@ -6,9 +6,9 @@ import cats.Semigroup
   *
   * Note: This case class contains mutable values
   */
-case class GfwProDashboardRawData(var totalArea: Double, var alertCount: Int) {
+case class GfwProDashboardRawData(var treeCoverExtentArea: Double, var alertCount: Int) {
   def merge(other: GfwProDashboardRawData): GfwProDashboardRawData = {
-    GfwProDashboardRawData(totalArea + other.totalArea, alertCount + other.alertCount)
+    GfwProDashboardRawData(treeCoverExtentArea + other.treeCoverExtentArea, alertCount + other.alertCount)
   }
 }
 

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawDataGroup.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawDataGroup.scala
@@ -4,11 +4,12 @@ import org.globalforestwatch.summarystats.forest_change_diagnostic.ForestChangeD
 import java.time.LocalDate
 
 case class GfwProDashboardRawDataGroup(
-  alertDate: Option[LocalDate]
+  alertDate: Option[LocalDate],
+  gladAlertsCoverage: Boolean
 ) {
     def toGfwProDashboardData(alertCount: Int, totalArea: Double): GfwProDashboardData = {
       GfwProDashboardData(
-        glad_alerts_coverage = alertDate.isDefined,
+        glad_alerts_coverage = gladAlertsCoverage,
         glad_alerts_daily = GfwProDashboardDataDateCount.fillDaily(alertDate, alertCount),
         glad_alerts_weekly = GfwProDashboardDataDateCount.fillWeekly(alertDate, alertCount),
         glad_alerts_monthly = GfwProDashboardDataDateCount.fillMonthly(alertDate, alertCount),


### PR DESCRIPTION
## Pull request type


Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Only record coverage if location has had a GLAD alert at any point in time.


## What is the new behavior?
Record coverage if location intersects a GLAD alert tile, and COULD have had a coverage at some point.
Also better names and comments for outputs to fix future selves from confusion.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

GLAD alerts do not cover the full globe:
![Screen Shot 2021-10-21 at 2 24 20 PM](https://user-images.githubusercontent.com/1158084/138335330-1b656b32-7038-45c3-be45-276adb555f2d.png)


