### PR TITLE
commodity value forest extent limited to 2019

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticData.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticData.scala
@@ -65,10 +65,15 @@ case class ForestChangeDiagnosticData(
   plantation_on_peat_area: ForestChangeDiagnosticDataDouble,
   plantation_in_protected_areas_area: ForestChangeDiagnosticDataDouble,
   commodity_value_forest_extent: ForestChangeDiagnosticDataValueYearly,
+  /** Repeats the peat_area value for each year of diagnostic, ease of use for commodity threat calc */
   commodity_value_peat: ForestChangeDiagnosticDataValueYearly,
+  /** Repeats the protected_areas_area value for each year of diagnostic, ease of use for commodity threat calc */
   commodity_value_protected_areas: ForestChangeDiagnosticDataValueYearly,
+  /** Sum of moving two year window over filtered_tree_cover_loss_yearly */
   commodity_threat_deforestation: ForestChangeDiagnosticDataLossYearly,
+  /** Sum of moving two year window over filtered_tree_cover_loss_peat_yearly + plantation_peat_area */
   commodity_threat_peat: ForestChangeDiagnosticDataLossYearly,
+  /** Sum of moving to year window over filtered_tree_cover_loss_protected_areas_yearly + plantation_in_protected_areas_area */
   commodity_threat_protected_areas: ForestChangeDiagnosticDataLossYearly,
   commodity_threat_fires: ForestChangeDiagnosticDataLossYearly
 ) {
@@ -156,6 +161,9 @@ case class ForestChangeDiagnosticData(
     )
   }
 
+  /**
+    * @see https://docs.google.com/presentation/d/1nAq4mFNkv1q5vFvvXWReuLr4Znvr-1q-BDi6pl_5zTU/edit#slide=id.p
+    */
   def withUpdatedCommodityRisk(): ForestChangeDiagnosticData = {
 
     /* Exclude the last year, limit data to 2019 to sync with palm risk tool:
@@ -171,11 +179,14 @@ case class ForestChangeDiagnosticData(
         filtered_tree_cover_extent.value,
         filtered_tree_cover_loss_yearly.value,
         2
-      )
+      ).limitToMaxYear(maxLossYear)
+
     val peatValueIndicator: ForestChangeDiagnosticDataValueYearly =
-      ForestChangeDiagnosticDataValueYearly.fill(peat_area.value)
+      ForestChangeDiagnosticDataValueYearly.fill(peat_area.value).limitToMaxYear(maxLossYear)
+
     val protectedAreaValueIndicator: ForestChangeDiagnosticDataValueYearly =
-      ForestChangeDiagnosticDataValueYearly.fill(protected_areas_area.value)
+      ForestChangeDiagnosticDataValueYearly.fill(protected_areas_area.value).limitToMaxYear(maxLossYear)
+
     val deforestationThreatIndicator: ForestChangeDiagnosticDataLossYearly =
       ForestChangeDiagnosticDataLossYearly(
         SortedMap(
@@ -196,7 +207,8 @@ case class ForestChangeDiagnosticData(
               })
           ): _*
         )
-      )
+      ).limitToMaxYear(maxLossYear)
+
     val peatThreatIndicator: ForestChangeDiagnosticDataLossYearly =
       ForestChangeDiagnosticDataLossYearly(
         SortedMap(
@@ -218,7 +230,8 @@ case class ForestChangeDiagnosticData(
               })
           ): _*
         )
-      )
+      ).limitToMaxYear(maxLossYear)
+
     val protectedAreaThreatIndicator: ForestChangeDiagnosticDataLossYearly =
       ForestChangeDiagnosticDataLossYearly(
         SortedMap(
@@ -239,7 +252,7 @@ case class ForestChangeDiagnosticData(
               })
           ): _*
         )
-      )
+      ).limitToMaxYear(maxLossYear)
 
     copy(
       commodity_value_forest_extent = forestValueIndicator,

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticDataValueYearly.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticDataValueYearly.scala
@@ -14,6 +14,10 @@ case class ForestChangeDiagnosticDataValueYearly(value: SortedMap[Int, Double])
     ForestChangeDiagnosticDataValueYearly(Semigroup[SortedMap[Int, Double]].combine(value, other.value))
   }
 
+  def limitToMaxYear(maxYear: Int): ForestChangeDiagnosticDataValueYearly= {
+    ForestChangeDiagnosticDataValueYearly(value.filterKeys{ year => year <= maxYear })
+  }
+
   def toJson: String = {
     this.round.asJson.noSpaces
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
commodity_value_forest_extent goes to 2020


## What is the new behavior?
commodity_value_forest_extent  is limited to 2019

Added a couple of comments and links to reference doc since its the second time I tweak this part of code.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
