### PR TITLE
Provide explicit flag to allow overwriting of output files

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/SummaryCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/SummaryCommand.scala
@@ -23,6 +23,13 @@ trait SummaryCommand {
   val outputOpt: Opts[String] =
     Opts.option[String]("output", "URI of output dir for CSV files")
 
+  val overwriteOutputOpt: Opts[Boolean] = Opts
+    .flag(
+      "overwrite",
+      help = "Overwrite output location if already existing"
+    )
+    .orFalse
+
   val featureTypeOpt: Opts[String] = Opts
     .option[String](
       "feature_type",
@@ -110,7 +117,7 @@ trait SummaryCommand {
   val noOutputPathSuffixOpt: Opts[Boolean] = Opts.flag("no_output_path_suffix", help = "Do not autogenerate output path suffix at runtime").orFalse
 
   val defaultOptions: Opts[BaseOptions] =
-    (featureTypeOpt, featuresOpt, outputOpt, splitFeatures, noOutputPathSuffixOpt).mapN(BaseOptions)
+    (featureTypeOpt, featuresOpt, outputOpt, overwriteOutputOpt, splitFeatures, noOutputPathSuffixOpt).mapN(BaseOptions)
 
   val fireAlertOptions: Opts[FireAlert] =
     (fireAlertTypeOpt, fireAlertSourceOpt).mapN(FireAlert)
@@ -152,6 +159,7 @@ object SummaryCommand {
     featureType: String,
     featureUris: NonEmptyList[String],
     outputUrl: String,
+    overwriteOutput: Boolean,
     splitFeatures: Boolean,
     noOutputPathSuffix: Boolean)
 

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
@@ -33,7 +33,8 @@ object ForestChangeDiagnosticCommand extends SummaryCommand with LazyLogging {
       ).mapN { (default, intermediateListSource, fireAlert, filterOptions) =>
       val kwargs = Map(
         "outputUrl" -> default.outputUrl,
-        "noOutputPathSuffix" -> default.noOutputPathSuffix
+        "noOutputPathSuffix" -> default.noOutputPathSuffix,
+        "overwriteOutput" -> default.overwriteOutput,
       )
 
       if (! default.splitFeatures) logger.warn("Forcing splitFeatures = true")

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
@@ -35,6 +35,7 @@ object GfwProDashboardCommand extends SummaryCommand {
       val kwargs = Map(
         "outputUrl" -> default.outputUrl,
         "noOutputPathSuffix" -> default.noOutputPathSuffix,
+        "overwriteOutput" -> default.overwriteOutput,
       )
       // TODO: move building the feature object into options
       val featureFilter = FeatureFilter.fromOptions(default.featureType, filterOptions)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When attempting to test, it can be a nuisance to have to target a new output location for repeated runs.  In the present code base, failing to specify an unused output location results in failures to write.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The new behavior allows the specification of an `--overwrite` flag that will allow successive test runs to re-use output locations.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
