### PR TITLE
Log out-of-bounds features

### DIFF
--- a/src/main/scala/org/globalforestwatch/features/ValidatedFeatureRDD.scala
+++ b/src/main/scala/org/globalforestwatch/features/ValidatedFeatureRDD.scala
@@ -2,8 +2,13 @@ package org.globalforestwatch.features
 
 import cats.data.{NonEmptyList, Validated}
 import com.vividsolutions.jts.geom.{
-  Envelope => GeoSparkEnvelope, Geometry => GeoSparkGeometry, Point => GeoSparkPoint, Polygon => GeoSparkPolygon,
-  MultiPolygon => GeoSparkMultiPolygon, Polygonal => GeoSparkPolygonal, GeometryCollection => GeoSparkGeometryCollection
+  Envelope => GeoSparkEnvelope,
+  Geometry => GeoSparkGeometry,
+  Point => GeoSparkPoint,
+  Polygon => GeoSparkPolygon,
+  MultiPolygon => GeoSparkMultiPolygon,
+  Polygonal => GeoSparkPolygonal,
+  GeometryCollection => GeoSparkGeometryCollection
 }
 import org.apache.log4j.Logger
 import geotrellis.store.index.zcurve.Z2
@@ -13,9 +18,9 @@ import org.apache.spark.HashPartitioner
 import org.apache.spark.api.java.JavaPairRDD
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.datasyslab.geospark.spatialRDD.SpatialRDD
+import org.datasyslab.geospark.spatialRDD.{SpatialRDD, PolygonRDD}
 import org.datasyslab.geosparksql.utils.Adapter
-import org.globalforestwatch.summarystats.{GeometryError, ValidatedRow}
+import org.globalforestwatch.summarystats.{JobError, NoIntersectionError, ValidatedRow}
 import org.globalforestwatch.util.{GridRDD, SpatialJoinRDD}
 import org.globalforestwatch.util.IntersectGeometry.{extractPolygons, validatedIntersection}
 import org.globalforestwatch.util.Util.getAnyMapValue
@@ -77,13 +82,28 @@ object ValidatedFeatureRDD {
     }
 
     val envelope: GeoSparkEnvelope = spatialFeatureRDD.boundaryEnvelope
-    val spatialGridRDD = GridRDD(envelope, spark, clip = true)
-    val flatJoin: JavaPairRDD[GeoSparkPolygon, GeoSparkGeometry] =
-      SpatialJoinRDD.flatSpatialJoin(
-        spatialFeatureRDD,
-        spatialGridRDD,
-        considerBoundaryIntersection = true
-      )
+    val spatialGridRDD = if (envelope != null) GridRDD(envelope, spark, clip = true) else new PolygonRDD(spark.sparkContext.emptyRDD[GeoSparkPolygon])
+
+    val matchedGeoms: RDD[(FeatureId, ValidatedRow[geotrellis.vector.Feature[Geometry, FeatureId]])] =
+      joinToGrid(spatialFeatureRDD, spatialGridRDD, spark, true)
+        .flatMap {
+          case (_, Validated.Valid(mp)) if mp.isEmpty =>
+            // This is Valid result of intersection, but with no area == not an intersection
+            None // flatMap will drop the None,
+          case (fid, validated) =>
+            val validatedFeature = validated.map { intersection =>
+              val geotrellisGeom: MultiPolygon = intersection
+              geotrellis.vector.Feature(geotrellisGeom, fid)
+            }
+            Some(fid -> validatedFeature)
+        }
+
+    // val flatJoin: JavaPairRDD[GeoSparkPolygon, GeoSparkGeometry] =
+    //   SpatialJoinRDD.flatSpatialJoin(
+    //     spatialFeatureRDD,
+    //     spatialGridRDD,
+    //     considerBoundaryIntersection = true
+    //   )
 
     /*
       partitions will come back very skewed and we will need to even them out for any downstream analysis
@@ -91,30 +111,121 @@ object ValidatedFeatureRDD {
       However, the range partitioner uses sampling to come up with the  break points for the different partitions.
       If the input RDD is already heavily skewed, sampling will be off and the range partitioner won't do a good job.
      */
-    val hashPartitioner = new HashPartitioner(flatJoin.getNumPartitions)
+    // val hashPartitioner = new HashPartitioner(flatJoin.getNumPartitions)
 
-     flatJoin.rdd
-      .keyBy({ pair: (GeoSparkPolygon, GeoSparkGeometry) =>
-        Z2(
-          (pair._1.getCentroid.getX * 100).toInt,
-          (pair._1.getCentroid.getY * 100).toInt
-        ).z
-      })
+    // val matchedGeoms: RDD[(FeatureId, ValidatedRow[geotrellis.vector.Feature[Geometry, FeatureId]])] = flatJoin.rdd
+    //   .keyBy({ pair: (GeoSparkPolygon, GeoSparkGeometry) =>
+    //     Z2(
+    //       (pair._1.getCentroid.getX * 100).toInt,
+    //       (pair._1.getCentroid.getY * 100).toInt
+    //     ).z
+    //   })
+    //   .partitionBy(hashPartitioner)
+    //   .flatMap { case (_, (gridCell, geom)) =>
+    //     val (fid, geometries) = validatedIntersection(geom, gridCell)
+    //     geometries.traverse { geoms => geoms }.map { vg => (fid.asInstanceOf[FeatureId], vg) }
+    //   }
+    //   .flatMap {
+    //     case (_, Validated.Valid(mp)) if mp.isEmpty =>
+    //       // This is Valid result of intersection, but with no area == not an intersection
+    //       None // flatMap will drop the None,
+    //     case (fid, validated) =>
+    //       val validatedFeature = validated.map { intersection =>
+    //         val geotrellisGeom: MultiPolygon = intersection
+    //         geotrellis.vector.Feature(geotrellisGeom, fid)
+    //       }
+    //       Some(fid -> validatedFeature)
+    //   }
+
+    val complementGridRDD = GridRDD.complement(envelope, spark)
+    val droppedGeoms: RDD[(FeatureId, ValidatedRow[geotrellis.vector.Feature[Geometry, FeatureId]])] =
+      joinToGrid(spatialFeatureRDD, complementGridRDD, spark)
+        .flatMap {
+          case (_, Validated.Valid(mp)) if mp.isEmpty =>
+            // Valid result of intersection with no area => not an intersection
+            None // flatMap will drop the None
+          case (fid, Validated.Valid(_)) =>
+            // There was a proper intersection; log the geometry as an out of bounds error
+            Some(fid)
+          case (fid, Validated.Invalid(_)) =>
+            // There was an intersection, but there was a JTS error in computing it; ignore
+            None
+        }
+        .distinct
+        .map{ fid => (fid, Validated.invalid[JobError, geotrellis.vector.Feature[Geometry, FeatureId]](NoIntersectionError)) }
+
+      // if (complementGridRDD.approximateTotalCount > 0) {
+      //   // look for features entirely outside of the tree cover grid area
+      //   val complementJoin: JavaPairRDD[GeoSparkPolygon, GeoSparkGeometry] =
+      //     SpatialJoinRDD.flatSpatialJoin(
+      //       spatialFeatureRDD,
+      //       complementGridRDD,
+      //       considerBoundaryIntersection = false
+      //     )
+      //   val cHashPartitioner = new HashPartitioner(complementJoin.getNumPartitions)
+      //   complementJoin.rdd
+      //     .keyBy({ pair: (GeoSparkPolygon, GeoSparkGeometry) =>
+      //       Z2(
+      //         (pair._1.getCentroid.getX * 100).toInt,
+      //         (pair._1.getCentroid.getY * 100).toInt
+      //       ).z
+      //     })
+      //     .partitionBy(cHashPartitioner)
+      //     .flatMap { case (_, (gridCell, geom)) =>
+      //       val (fid, geometries) = validatedIntersection(geom, gridCell)
+      //       geometries.traverse { geoms => geoms }.map { vg => (fid.asInstanceOf[FeatureId], vg) }
+      //     }
+      //     .flatMap {
+      //       case (_, Validated.Valid(mp)) if mp.isEmpty =>
+      //         // Valid result of intersection with no area => not an intersection
+      //         None // flatMap will drop the None
+      //       case (fid, Validated.Valid(_)) =>
+      //         // There was a proper intersection; log the geometry as an out of bounds error
+      //         Some(fid)
+      //       case (fid, Validated.Invalid(_)) =>
+      //         // There was an intersection, but there was a JTS error in computing it; ignore
+      //         None
+      //     }
+      //     .distinct
+      //     .map{ fid => (fid, Validated.invalid[JobError, geotrellis.vector.Feature[Geometry, FeatureId]](NoIntersectionError)) }
+      // } else {
+      //   spark.sparkContext.emptyRDD[(FeatureId, ValidatedRow[geotrellis.vector.Feature[Geometry, FeatureId]])]
+      // }
+
+    matchedGeoms.union(droppedGeoms)
+  }
+
+  private def joinToGrid(
+    spatialFeatureRdd: SpatialRDD[GeoSparkGeometry],
+    gridRdd: PolygonRDD,
+    spark: SparkSession,
+    considerBoundaryIntersection: Boolean = false
+  ): RDD[(FeatureId, ValidatedRow[GeoSparkMultiPolygon])] = {
+    if (gridRdd.approximateTotalCount > 0) {
+      // look for features entirely outside of the tree cover grid area
+      val joined: JavaPairRDD[GeoSparkPolygon, GeoSparkGeometry] =
+        SpatialJoinRDD.flatSpatialJoin(
+          spatialFeatureRdd,
+          gridRdd,
+          considerBoundaryIntersection
+        )
+      val hashPartitioner = new HashPartitioner(joined.getNumPartitions)
+      joined.rdd
+        .keyBy({ pair: (GeoSparkPolygon, GeoSparkGeometry) =>
+          Z2(
+            (pair._1.getCentroid.getX * 100).toInt,
+            (pair._1.getCentroid.getY * 100).toInt
+          ).z
+        })
       .partitionBy(hashPartitioner)
       .flatMap { case (_, (gridCell, geom)) =>
         val (fid, geometries) = validatedIntersection(geom, gridCell)
-        geometries.traverse { geoms => geoms }.map { vg => (fid.asInstanceOf[FeatureId], vg) }
+        geometries.traverse { geoms => geoms }.map {
+          vg => (fid.asInstanceOf[FeatureId], vg)
+        }
       }
-      .flatMap {
-        case (_, Validated.Valid(mp)) if mp.isEmpty =>
-          // This is Valid result of intersection, but with no area == not an intersection
-          None // flatMap will drop the None,
-        case (fid, validated) =>
-          val validatedFeature = validated.map { intersection =>
-            val geotrellisGeom: MultiPolygon = intersection
-            geotrellis.vector.Feature(geotrellisGeom, fid)
-          }
-          Some(fid -> validatedFeature)
-      }
+    } else {
+      spark.sparkContext.emptyRDD
+    }
   }
 }

--- a/src/main/scala/org/globalforestwatch/summarystats/SummaryCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/SummaryCommand.scala
@@ -23,6 +23,13 @@ trait SummaryCommand {
   val outputOpt: Opts[String] =
     Opts.option[String]("output", "URI of output dir for CSV files")
 
+  val overwriteOutputOpt: Opts[Boolean] = Opts
+    .flag(
+      "overwrite",
+      help = "Overwrite output location if already existing"
+    )
+    .orFalse
+
   val featureTypeOpt: Opts[String] = Opts
     .option[String](
       "feature_type",
@@ -110,7 +117,7 @@ trait SummaryCommand {
   val noOutputPathSuffixOpt: Opts[Boolean] = Opts.flag("no_output_path_suffix", help = "Do not autogenerate output path suffix at runtime").orFalse
 
   val defaultOptions: Opts[BaseOptions] =
-    (featureTypeOpt, featuresOpt, outputOpt, splitFeatures, noOutputPathSuffixOpt).mapN(BaseOptions)
+    (featureTypeOpt, featuresOpt, outputOpt, overwriteOutputOpt, splitFeatures, noOutputPathSuffixOpt).mapN(BaseOptions)
 
   val fireAlertOptions: Opts[FireAlert] =
     (fireAlertTypeOpt, fireAlertSourceOpt).mapN(FireAlert)
@@ -152,6 +159,7 @@ object SummaryCommand {
     featureType: String,
     featureUris: NonEmptyList[String],
     outputUrl: String,
+    overwriteOutput: Boolean,
     splitFeatures: Boolean,
     noOutputPathSuffix: Boolean)
 

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
@@ -33,7 +33,8 @@ object ForestChangeDiagnosticCommand extends SummaryCommand with LazyLogging {
       ).mapN { (default, intermediateListSource, fireAlert, filterOptions) =>
       val kwargs = Map(
         "outputUrl" -> default.outputUrl,
-        "noOutputPathSuffix" -> default.noOutputPathSuffix
+        "noOutputPathSuffix" -> default.noOutputPathSuffix,
+        "overwriteOutput" -> default.overwriteOutput,
       )
 
       if (! default.splitFeatures) logger.warn("Forcing splitFeatures = true")

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
@@ -35,6 +35,7 @@ object GfwProDashboardCommand extends SummaryCommand {
       val kwargs = Map(
         "outputUrl" -> default.outputUrl,
         "noOutputPathSuffix" -> default.noOutputPathSuffix,
+        "overwriteOutput" -> default.overwriteOutput,
       )
       // TODO: move building the feature object into options
       val featureFilter = FeatureFilter.fromOptions(default.featureType, filterOptions)

--- a/src/main/scala/org/globalforestwatch/util/SpatialJoinRDD.scala
+++ b/src/main/scala/org/globalforestwatch/util/SpatialJoinRDD.scala
@@ -13,12 +13,12 @@ import scala.reflect.ClassTag
 object SpatialJoinRDD {
 
   def spatialjoin[A <: Geometry : ClassTag, B <: Geometry : ClassTag](
-                                                                       queryWindowRDD: SpatialRDD[A],
-                                                                       valueRDD: SpatialRDD[B],
-                                                                       buildOnSpatialPartitionedRDD: Boolean = true, // Set to TRUE only if run join query
-                                                                       considerBoundaryIntersection: Boolean = false, // Only return gemeotries fully covered by each query window in queryWindowRDD
-                                                                       usingIndex: Boolean = false
-                                                                     ): JavaPairRDD[A, util.HashSet[B]] = {
+    queryWindowRDD: SpatialRDD[A],
+    valueRDD: SpatialRDD[B],
+    buildOnSpatialPartitionedRDD: Boolean = true, // Set to TRUE only if run join query
+    considerBoundaryIntersection: Boolean = false, // Only return gemeotries fully covered by each query window in queryWindowRDD
+    usingIndex: Boolean = false
+  ): JavaPairRDD[A, util.HashSet[B]] = {
 
     try {
       queryWindowRDD.spatialPartitioning(GridType.QUADTREE)
@@ -69,12 +69,12 @@ object SpatialJoinRDD {
   }
 
   def flatSpatialJoin[A <: Geometry : ClassTag, B <: Geometry : ClassTag](
-                                                                           queryWindowRDD: SpatialRDD[A],
-                                                                           valueRDD: SpatialRDD[B],
-                                                                           buildOnSpatialPartitionedRDD: Boolean = true, // Set to TRUE only if run join query
-                                                                           considerBoundaryIntersection: Boolean = false, // Only return gemeotries fully covered by each query window in queryWindowRDD
-                                                                           usingIndex: Boolean = false
-                                                                         ): JavaPairRDD[B, A] = {
+    queryWindowRDD: SpatialRDD[A],
+    valueRDD: SpatialRDD[B],
+    buildOnSpatialPartitionedRDD: Boolean = true, // Set to TRUE only if run join query
+    considerBoundaryIntersection: Boolean = false, // Only return gemeotries fully covered by each query window in queryWindowRDD
+    usingIndex: Boolean = false
+  ): JavaPairRDD[B, A] = {
 
     val queryWindowCount = queryWindowRDD.approximateTotalCount
     val queryWindowPartitions = queryWindowRDD.rawSpatialRDD.getNumPartitions
@@ -136,9 +136,9 @@ object SpatialJoinRDD {
   }
 
   private def bruteForceJoin[A <: Geometry : ClassTag, B <: Geometry : ClassTag](
-                                                                                  leftRDD: SpatialRDD[A],
-                                                                                  rightRDD: SpatialRDD[B]
-                                                                                ): JavaPairRDD[A, util.HashSet[B]] = {
+    leftRDD: SpatialRDD[A],
+    rightRDD: SpatialRDD[B]
+  ): JavaPairRDD[A, util.HashSet[B]] = {
     JavaPairRDD.fromRDD(
       leftRDD.rawSpatialRDD.rdd
         .cartesian(rightRDD.rawSpatialRDD.rdd)
@@ -153,17 +153,15 @@ object SpatialJoinRDD {
     )
   }
 
-  private def bruteForceFlatJoin[A <: Geometry : ClassTag,
-    B <: Geometry : ClassTag](
-                               leftRDD: SpatialRDD[A],
-                               rightRDD: SpatialRDD[B]
-                             ): JavaPairRDD[A, B] = {
+  private def bruteForceFlatJoin[A <: Geometry : ClassTag, B <: Geometry : ClassTag](
+    leftRDD: SpatialRDD[A],
+    rightRDD: SpatialRDD[B]
+  ): JavaPairRDD[A, B] = {
     JavaPairRDD.fromRDD(
       leftRDD.rawSpatialRDD.rdd
         .cartesian(rightRDD.rawSpatialRDD.rdd)
         .filter((pair: (Geometry, Geometry)) => pair._1.intersects(pair._2))
     )
-
   }
 
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If inputs contain geometries that do not intersect the tree cover loss raster extent, those geometries will be lost.  If the input contains *only* non-intersecting geometries, `ForestChangeDiagnoticCommand` will fail outright.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

I introduce a complementary join to `ValidatedFeatureRDD` that will identify geometries that have no intersection with the tree cover loss extent, and will track their feature IDs as `NoIntersectionError`s.  These will be propagated into the output.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

A test input containing only two out-of-bounds geometries yields the following final output:
```
list_id location_id     status_code     location_error  tree_cover_loss_total_yearly    tree_cover_loss_primary_forest_yearly   tree_cover_loss_peat_yearly     tree_cover_loss_intact_forest_yearly    tree_cover_loss_protected_areas_yearly  tree_cover_loss_sea_landcover_yearly    tree_cover_loss_idn_landcover_yearly    tree_cover_loss_soy_yearly      tree_cover_loss_idn_legal_yearly        tree_cover_loss_idn_forest_moratorium_yearly    tree_cover_loss_prodes_yearly   tree_cover_loss_prodes_wdpa_yearly      tree_cover_loss_prodes_primary_forest_yearly    tree_cover_loss_brazil_biomes_yearly    tree_cover_extent_total tree_cover_extent_primary_forest        tree_cover_extent_protected_areas       tree_cover_extent_peat  tree_cover_extent_intact_forest natural_habitat_primary natural_habitat_intact_forest   total_area      protected_areas_area    peat_area       brazil_biomes   idn_legal_area  sea_landcover_area      idn_landcover_area      idn_forest_moratorium_area      south_america_presence  legal_amazon_presence   brazil_biomes_presence  cerrado_biome_presence  southeast_asia_presence indonesia_presence      commodity_value_forest_extent   commodity_value_peat    commodity_value_protected_areas commodity_threat_deforestation  commodity_threat_peat   commodity_threat_protected_areas        commodity_threat_fires
266     1       3       ["NoIntersectionError"] {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      0.0     0.0     0.0     0.0     0.0     0.0     0.0     0.0     0.0     0.0     {}      {}      {}      {}      0.0     false   false   false   false   false   false   {}      {}      {}      {}      {}      {}      {}
266     -1      3       ["NoIntersectionError"] {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      {}      0.0     0.0     0.0     0.0     0.0     0.0     0.0     0.0     0.0     0.0     {}      {}      {}      {}      0.0     false   false   false   false   false   false   {}      {}      {}      {}      {}      {}      {}
```