### PR TITLE
Use HashPartitioner with splitting during PolygonalSummary

### DIFF
--- a/src/main/scala/org/globalforestwatch/util/PartitionSkewedRDD.scala
+++ b/src/main/scala/org/globalforestwatch/util/PartitionSkewedRDD.scala
@@ -1,0 +1,49 @@
+package org.globalforestwatch.util
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.HashPartitioner
+
+object RepartitionSkewedRDD {
+  def bySparseId[A: ClassTag](rdd: RDD[(Long, A)], maxPartitionSize: Int): RDD[A] = {
+    val counts = rdd.map{ case (id, _) => (id, 1l) }.reduceByKey(_ + _).collect().sortBy(_._2)
+    val totalCount = counts.map(_._2).sum
+    val splits = PartitionSplit.fromCounts(counts, maxPartitionSize)
+    val paritionIndex: (Long, A) => Int = (id, v) => splits(id).partitionForRow(v)
+    val numPartitions: Int = math.min((totalCount / 1024).toInt, 2000)
+    println(s"numPartitions: ${numPartitions}")
+
+    rdd
+      .map { case (id, v) => (paritionIndex(id, v), v) }
+      .partitionBy(new HashPartitioner(numPartitions))
+      .values
+  }
+}
+
+
+case class PartitionSplit(partitionIndex: Int,  splits: Int) {
+  require(splits >= 0, s"Min of one split required: $splits")
+
+  def maxPartitionIndex: Int = partitionIndex + splits - 1
+
+  def partitionForRow[A](row: A): Int = {
+    partitionIndex + row.hashCode() % splits
+  }
+}
+
+object PartitionSplit {
+  def fromCounts(counts: Seq[(Long, Long)], maxPartitionSize: Int): Map[Long, PartitionSplit] = {
+    counts.foldLeft(List.empty[(Long, PartitionSplit)]) {
+      case (Nil, (id, count)) =>
+        val index = 0
+        val splits = math.ceil(count.toDouble / maxPartitionSize).toInt
+        id -> PartitionSplit(index, splits) :: Nil
+
+      case (acc@((_, head) :: _), (id, count)) =>
+        val index = head.partitionIndex + head.splits
+        val splits = math.ceil(count.toDouble / maxPartitionSize).toInt
+        id -> PartitionSplit(index, splits) :: acc
+    }.toMap
+  }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Using RangePartitioner on z-index of tile

## What is the new behavior?
Using HashPartitioner

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a performance oriented change.
In the context the work that's being done is fetching raster tiles, each named by a z-index and performing polygonal summary for overlapping geometries. The features are grouped per tile in the partition to avoid re-fetching tiles (which is expensive)

There are two cases where partitioning here can become a problem:
1. Heavy data skew on few tiles
There are only a few tiles and they have a lot of features. Ideally the features can be spread among several partitions so the work can be done in parallel and partitions don't lag

2. Multiple partitions fetch all the same tiles
This assumes there are "few" features per tile but now we can have the work spread among too many partitions and we're paying tile transfer costs for no reasons.

Thankfully because we're working over 1x1 degree grid here we can never have "too many" tiles overall and it's safe to collect the full distribution of our job before we decide how to partition it. This allows us to split any tile that have too many features (more than 4k) into multiple records (on different partitions). This works out because the index of each split is sequential and we can expect that hash to put them on different partitions as long as partition count is greater than split count (it will always be). The default case is for all the other features to be gathered on a single partition corresponding to their tile index. The order of tiles does not matter, because our unit of work is per tile, and we can hash over the partition count to try to get better distribution.

In testing so far this has been working well.

Some changes that may become desirable later is to decide how many tiles you want per-partition, this will give constant partition execution time (more or less).

