### PR TITLE
Partition by tile count during summary

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/ErrorSummaryRDD.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/ErrorSummaryRDD.scala
@@ -59,15 +59,12 @@ trait ErrorSummaryRDD extends LazyLogging with java.io.Serializable {
      * but still preserving locality which will both reduce the S3 reads per executor and make it more likely
      * for features to be close together already during export.
      */
-
     val partitionedFeatureRDD = if (partition) {
       // if a single tile has more than 4096 features, split it up over partitions
       RepartitionSkewedRDD.bySparseId(keyedFeatureRDD, 4096)
     } else {
       keyedFeatureRDD.values
     }
-
-    // countRecordsPerPartition(partitionedFeatureRDD, SummarySparkSession("tmp"))
 
     /*
      * Here we're going to work with the features one partition at a time.

--- a/src/main/scala/org/globalforestwatch/util/PartitionSkewedRDD.scala
+++ b/src/main/scala/org/globalforestwatch/util/PartitionSkewedRDD.scala
@@ -8,11 +8,10 @@ import org.apache.spark.HashPartitioner
 object RepartitionSkewedRDD {
   def bySparseId[A: ClassTag](rdd: RDD[(Long, A)], maxPartitionSize: Int): RDD[A] = {
     val counts = rdd.map{ case (id, _) => (id, 1l) }.reduceByKey(_ + _).collect().sortBy(_._2)
-    val totalCount = counts.map(_._2).sum
     val splits = PartitionSplit.fromCounts(counts, maxPartitionSize)
     val paritionIndex: (Long, A) => Int = (id, v) => splits(id).partitionForRow(v)
-    val numPartitions: Int = math.min((totalCount / 1024).toInt, 2000)
-    println(s"numPartitions: ${numPartitions}")
+    val parallelism = rdd.sparkContext.defaultParallelism
+    val numPartitions: Int = math.max(parallelism, splits.size / 16).toInt
 
     rdd
       .map { case (id, v) => (paritionIndex(id, v), v) }


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Partition by total number of features.


## What is the new behavior?
Partition by number of tiles needed to be downloaded.
At minimum we'll respect default parallelism to give lowest runtime on small jobs.
Otherwise cap at 16 tiles per partition which seems.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->