### PR TITLE
Disable GDAL options set for read optimization

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -26,9 +26,9 @@ geotrellis.jts = {
 }
 
 geotrellis.raster.gdal.options {
-  GDAL_NUM_THREADS                 = "ALL_CPUS"
-  GDAL_DISABLE_READDIR_ON_OPEN     = "YES"
-  GDAL_MAX_DATASET_POOL_SIZE       = "512"
+  # GDAL_NUM_THREADS                 = "ALL_CPUS"
+  # GDAL_DISABLE_READDIR_ON_OPEN     = "YES"
+  # GDAL_MAX_DATASET_POOL_SIZE       = "512"
   # GDAL_CACHEMAX                    = "1000"
   # CPL_VSIL_GZIP_WRITE_PROPERTIES   = "NO"
   # CPL_VSIL_CURL_CHUNK_SIZE         = "64000"


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
GDAL options are set to increase raster read speed, but seem to be causing some deadlocking issues with GDAL leading to very slow read speeds on Batch.


## What is the new behavior?
Disable GDAL options and just use defaults.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

