### PR TITLE
Force Java version during publish action to 11.0.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 11.0.19
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
Force Java version during publish action to 11.0.19

Temurin just recently upgrade their latest Java 11 version to 11.0.20, but that causes an error (bad scalactic_2.12-3.2.5.jar file [Invalid CEN header (invalid zip64 extra data field size)]) during build assembly step of publish action, so we need to lock in the version to 11.0.19

Tested via a feature branch which allowed testing of the publish action (via some other temporary mods to ci.yaml).
