### PR TITLE
Change to using the licensed WDPA dataset.

### DIFF
--- a/src/main/resources/raster-catalog-pro.json
+++ b/src/main/resources/raster-catalog-pro.json
@@ -14,7 +14,7 @@
     },
     {
       "name":"detailed_wdpa_protected_areas",
-      "source_uri":"s3://gfw-data-lake/wdpa_protected_areas/v202308/raster/epsg-4326/{grid_size}/{row_count}/detailed_iucn_cat/gdal-geotiff/{tile_id}.tif"
+      "source_uri":"s3://gfw-data-lake/wdpa_licensed_protected_areas/v202310/raster/epsg-4326/{grid_size}/{row_count}/detailed_iucn_cat/gdal-geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_oil_gas",


### PR DESCRIPTION
Change to using the Oct 2023 licensed WDPA dataset for GFWPro
(rather than the public WDPA dataset).  Just changing the catalog.

Verified that the output for several input sets stayed the same with the licensed WDPA dataset.


