### PR TITLE
Replace glad with integrated alerts in gfwpro_dashboard.

### DIFF
--- a/src/main/resources/raster-catalog-pro.json
+++ b/src/main/resources/raster-catalog-pro.json
@@ -319,6 +319,10 @@
     {
       "name": "gfwpro_negligible_risk_analysis",
       "source_uri": "s3://gfw-data-lake/gfwpro_negligible_risk_analysis/v20230726/raster/epsg-4326/{grid_size}/{row_count}/risk/geotiff/{tile_id}.tif"
+    },
+    {
+      "name":"gfw_integrated_alerts",
+      "source_uri": "s3://gfw-data-lake/gfw_integrated_alerts/latest/raster/epsg-4326/{grid_size}/{row_count}/date_conf/geotiff/{tile_id}.tif"
     }
   ]
 }

--- a/src/main/scala/org/globalforestwatch/layers/IntegratedAlerts.scala
+++ b/src/main/scala/org/globalforestwatch/layers/IntegratedAlerts.scala
@@ -1,0 +1,10 @@
+package org.globalforestwatch.layers
+
+import org.globalforestwatch.grids.GridTile
+
+case class IntegratedAlerts(gridTile: GridTile, kwargs: Map[String, Any]) extends DateConfLevelsLayer with OptionalILayer {
+  val datasetName = "gfw_integrated_alerts"
+
+  val uri: String =
+    uriForGrid(gridTile, kwargs)
+}

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardData.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardData.scala
@@ -9,27 +9,31 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
   * Note: This case class contains mutable values
   */
 case class GfwProDashboardData(
+  /* NOTE: We are temporarily leaving the integrated_alerts_* fields named as
+   * glad_alerts_*, in order to reduce the number of moving pieces as we move from
+   * Glad alerts to integrated alerts in GFWPro. */
+
   /** Location intersects Integrated Alert tiles, integrated alerts are possible */
-  integrated_alerts_coverage: Boolean,
+  glad_alerts_coverage: Boolean,
   /** How many hectares of location geometry had tree cover extent > 30%  in 2000 */
   tree_cover_extent_total: ForestChangeDiagnosticDataDouble,
   /** Integrated alert count within location geometry grouped by day */
-  integrated_alerts_daily: GfwProDashboardDataDateCount,
+  glad_alerts_daily: GfwProDashboardDataDateCount,
   /** Integrated alert count within location geometry grouped by ISO year-week */
-  integrated_alerts_weekly: GfwProDashboardDataDateCount,
+  glad_alerts_weekly: GfwProDashboardDataDateCount,
   /** Integrated alert count within location geometry grouped by year-month */
-  integrated_alerts_monthly: GfwProDashboardDataDateCount,
+  glad_alerts_monthly: GfwProDashboardDataDateCount,
   /** VIIRS alerts for location geometry grouped by day */
   viirs_alerts_daily: GfwProDashboardDataDateCount,
 ) {
 
   def merge(other: GfwProDashboardData): GfwProDashboardData = {
     GfwProDashboardData(
-      integrated_alerts_coverage || other.integrated_alerts_coverage,
+      glad_alerts_coverage || other.glad_alerts_coverage,
       tree_cover_extent_total.merge(other.tree_cover_extent_total),
-      integrated_alerts_daily.merge(other.integrated_alerts_daily),
-      integrated_alerts_weekly.merge(other.integrated_alerts_weekly),
-      integrated_alerts_monthly.merge(other.integrated_alerts_monthly),
+      glad_alerts_daily.merge(other.glad_alerts_daily),
+      glad_alerts_weekly.merge(other.glad_alerts_weekly),
+      glad_alerts_monthly.merge(other.glad_alerts_monthly),
       viirs_alerts_daily.merge(other.viirs_alerts_daily)
     )
   }
@@ -39,7 +43,7 @@ object GfwProDashboardData {
 
   def empty: GfwProDashboardData =
     GfwProDashboardData(
-      integrated_alerts_coverage = false,
+      glad_alerts_coverage = false,
       tree_cover_extent_total = ForestChangeDiagnosticDataDouble.empty,
       GfwProDashboardDataDateCount.empty,
       GfwProDashboardDataDateCount.empty,

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardData.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardData.scala
@@ -9,27 +9,27 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
   * Note: This case class contains mutable values
   */
 case class GfwProDashboardData(
-  /** Location intersects GLAD Alert tiles, GLAD alerts are possible */
-  glad_alerts_coverage: Boolean,
-  /** How many hacters of location geometry had tree cover extent > 30%  in 2000 */
+  /** Location intersects Integrated Alert tiles, integrated alerts are possible */
+  integrated_alerts_coverage: Boolean,
+  /** How many hectares of location geometry had tree cover extent > 30%  in 2000 */
   tree_cover_extent_total: ForestChangeDiagnosticDataDouble,
-  /** GLAD alert count within location geometry grouped by day */
-  glad_alerts_daily: GfwProDashboardDataDateCount,
-  /** GLAD alert count within location geometry grouped by ISO year-week */
-  glad_alerts_weekly: GfwProDashboardDataDateCount,
-  /** GLAD alert count within location geometry grouped by year-month */
-  glad_alerts_monthly: GfwProDashboardDataDateCount,
+  /** Integrated alert count within location geometry grouped by day */
+  integrated_alerts_daily: GfwProDashboardDataDateCount,
+  /** Integrated alert count within location geometry grouped by ISO year-week */
+  integrated_alerts_weekly: GfwProDashboardDataDateCount,
+  /** Integrated alert count within location geometry grouped by year-month */
+  integrated_alerts_monthly: GfwProDashboardDataDateCount,
   /** VIIRS alerts for location geometry grouped by day */
   viirs_alerts_daily: GfwProDashboardDataDateCount,
 ) {
 
   def merge(other: GfwProDashboardData): GfwProDashboardData = {
     GfwProDashboardData(
-      glad_alerts_coverage || other.glad_alerts_coverage,
+      integrated_alerts_coverage || other.integrated_alerts_coverage,
       tree_cover_extent_total.merge(other.tree_cover_extent_total),
-      glad_alerts_daily.merge(other.glad_alerts_daily),
-      glad_alerts_weekly.merge(other.glad_alerts_weekly),
-      glad_alerts_monthly.merge(other.glad_alerts_monthly),
+      integrated_alerts_daily.merge(other.integrated_alerts_daily),
+      integrated_alerts_weekly.merge(other.integrated_alerts_weekly),
+      integrated_alerts_monthly.merge(other.integrated_alerts_monthly),
       viirs_alerts_daily.merge(other.viirs_alerts_daily)
     )
   }
@@ -39,7 +39,7 @@ object GfwProDashboardData {
 
   def empty: GfwProDashboardData =
     GfwProDashboardData(
-      glad_alerts_coverage = false,
+      integrated_alerts_coverage = false,
       tree_cover_extent_total = ForestChangeDiagnosticDataDouble.empty,
       GfwProDashboardDataDateCount.empty,
       GfwProDashboardDataDateCount.empty,

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardGrid.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardGrid.scala
@@ -1,10 +1,10 @@
 package org.globalforestwatch.summarystats.gfwpro_dashboard
 
 import geotrellis.vector.Extent
-import org.globalforestwatch.grids.{GridTile, TenByTen30mGrid}
+import org.globalforestwatch.grids.{GridTile, TenByTen10mGrid}
 
 object GfwProDashboardGrid
-  extends TenByTen30mGrid[GfwProDashboardGridSources] {
+  extends TenByTen10mGrid[GfwProDashboardGridSources] {
 
   val gridExtent: Extent = Extent(-180.0000, -90.0000, 180.0000, 90.0000)
 

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardGridSources.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardGridSources.scala
@@ -10,7 +10,7 @@ import org.globalforestwatch.layers._
   * @param gridTile top left corner, padded from east ex: "10N_010E"
   */
 case class GfwProDashboardGridSources(gridTile: GridTile, kwargs: Map[String, Any]) extends GridSources {
-  val gladAlerts = GladAlerts(gridTile, kwargs)
+  val integratedAlerts = IntegratedAlerts(gridTile, kwargs)
   val treeCoverDensity2000 = TreeCoverDensityPercent2000(gridTile, kwargs)
 
   def readWindow(
@@ -19,15 +19,15 @@ case class GfwProDashboardGridSources(gridTile: GridTile, kwargs: Map[String, An
                 ): Either[Throwable, Raster[GfwProDashboardTile]] = {
 
     for {
-      // Glad alerts are Optional Tiles, but we keep it this way to avoid signature changes
-      gladAlertsTile <- Either
-        .catchNonFatal(gladAlerts.fetchWindow(windowKey, windowLayout))
+      // Integrated alerts are Optional Tiles, but we keep it this way to avoid signature changes
+      integratedAlertsTile <- Either
+        .catchNonFatal(integratedAlerts.fetchWindow(windowKey, windowLayout))
         .right
       tcd2000Tile <- Either
         .catchNonFatal(treeCoverDensity2000.fetchWindow(windowKey, windowLayout))
         .right
     } yield {
-      val tile = GfwProDashboardTile(gladAlertsTile, tcd2000Tile)
+      val tile = GfwProDashboardTile(integratedAlertsTile, tcd2000Tile)
       Raster(tile, windowKey.extent(windowLayout))
     }
   }

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawDataGroup.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawDataGroup.scala
@@ -9,10 +9,10 @@ case class GfwProDashboardRawDataGroup(
 ) {
     def toGfwProDashboardData(alertCount: Int, totalArea: Double): GfwProDashboardData = {
       GfwProDashboardData(
-        integrated_alerts_coverage = integratedAlertsCoverage,
-        integrated_alerts_daily = GfwProDashboardDataDateCount.fillDaily(alertDate, alertCount),
-        integrated_alerts_weekly = GfwProDashboardDataDateCount.fillWeekly(alertDate, alertCount),
-        integrated_alerts_monthly = GfwProDashboardDataDateCount.fillMonthly(alertDate, alertCount),
+        glad_alerts_coverage = integratedAlertsCoverage,
+        glad_alerts_daily = GfwProDashboardDataDateCount.fillDaily(alertDate, alertCount),
+        glad_alerts_weekly = GfwProDashboardDataDateCount.fillWeekly(alertDate, alertCount),
+        glad_alerts_monthly = GfwProDashboardDataDateCount.fillMonthly(alertDate, alertCount),
         viirs_alerts_daily = GfwProDashboardDataDateCount.empty,
         tree_cover_extent_total = ForestChangeDiagnosticDataDouble.fill(totalArea))
   }

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawDataGroup.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawDataGroup.scala
@@ -5,14 +5,14 @@ import java.time.LocalDate
 
 case class GfwProDashboardRawDataGroup(
   alertDate: Option[LocalDate],
-  gladAlertsCoverage: Boolean
+  integratedAlertsCoverage: Boolean
 ) {
     def toGfwProDashboardData(alertCount: Int, totalArea: Double): GfwProDashboardData = {
       GfwProDashboardData(
-        glad_alerts_coverage = gladAlertsCoverage,
-        glad_alerts_daily = GfwProDashboardDataDateCount.fillDaily(alertDate, alertCount),
-        glad_alerts_weekly = GfwProDashboardDataDateCount.fillWeekly(alertDate, alertCount),
-        glad_alerts_monthly = GfwProDashboardDataDateCount.fillMonthly(alertDate, alertCount),
+        integrated_alerts_coverage = integratedAlertsCoverage,
+        integrated_alerts_daily = GfwProDashboardDataDateCount.fillDaily(alertDate, alertCount),
+        integrated_alerts_weekly = GfwProDashboardDataDateCount.fillWeekly(alertDate, alertCount),
+        integrated_alerts_monthly = GfwProDashboardDataDateCount.fillMonthly(alertDate, alertCount),
         viirs_alerts_daily = GfwProDashboardDataDateCount.empty,
         tree_cover_extent_total = ForestChangeDiagnosticDataDouble.fill(totalArea))
   }

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardSummary.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardSummary.scala
@@ -39,11 +39,11 @@ object GfwProDashboardSummary {
 
       def visit(raster: Raster[GfwProDashboardTile], col: Int, row: Int): Unit = {
         val tcd2000: Integer = raster.tile.tcd2000.getData(col, row)
-        val gladAlertDate: Option[LocalDate] = raster.tile.gladAlerts.getData(col, row).map { case (date, _) => date }
-        val gladAlertCoverage = raster.tile.gladAlerts.t.isDefined
+        val integratedAlertDate: Option[LocalDate] = raster.tile.integratedAlerts.getData(col, row).map { case (date, _) => date }
+        val integratedAlertCoverage = raster.tile.integratedAlerts.t.isDefined
         val isTreeCoverExtent30: Boolean = tcd2000 > 30
 
-        val groupKey = GfwProDashboardRawDataGroup(gladAlertDate, gladAlertsCoverage = gladAlertCoverage)
+        val groupKey = GfwProDashboardRawDataGroup(integratedAlertDate, integratedAlertsCoverage = integratedAlertCoverage)
         val summaryData = acc.stats.getOrElse(groupKey, GfwProDashboardRawData(treeCoverExtentArea = 0.0, alertCount = 0))
 
         if (isTreeCoverExtent30) {
@@ -51,7 +51,7 @@ object GfwProDashboardSummary {
           summaryData.treeCoverExtentArea += areaHa
         }
 
-        if (gladAlertDate.isDefined) {
+        if (integratedAlertDate.isDefined) {
           summaryData.alertCount += 1
         }
 

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardTile.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardTile.scala
@@ -9,13 +9,13 @@ import org.globalforestwatch.layers._
   * We can not use GeoTrellis MultibandTile because it requires all bands share a CellType.
   */
 case class GfwProDashboardTile(
-  gladAlerts: GladAlerts#OptionalITile,
+  integratedAlerts: IntegratedAlerts#OptionalITile,
   tcd2000: TreeCoverDensityPercent2000#ITile
 ) extends CellGrid[Int] {
 
-  def cellType: CellType = gladAlerts.cellType.getOrElse(IntCellType)
+  def cellType: CellType = integratedAlerts.cellType.getOrElse(IntCellType)
 
-  def cols: Int = gladAlerts.cols.getOrElse(GfwProDashboardGrid.blockSize)
+  def cols: Int = integratedAlerts.cols.getOrElse(GfwProDashboardGrid.blockSize)
 
-  def rows: Int = gladAlerts.rows.getOrElse(GfwProDashboardGrid.blockSize)
+  def rows: Int = integratedAlerts.rows.getOrElse(GfwProDashboardGrid.blockSize)
 }


### PR DESCRIPTION
Replace glad with integrated alerts in gfwpro_dashboard.

Many of these changes come from Justin's original prototype, including the switch to the 10x10m grid.

Added a new DataConfLevelsLayer that decodes three levels of confidence.  The other confidence layer DataConfLayer only decodes two levels and returns a Boolean.  So, I added a new layer, so that the existing code using DataConfLayer that expects a boolean doesn't all have to change.

In order to reduce the number of things that are changing, we are intentionally keeping the glad_* column names in the output, rather than switching to integrated_*.  We will update those in a later change, such as when we add in confidence levels in the output.
