### PR TITLE
Use iso year instead of normal year for alert__year

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsDF.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsDF.scala
@@ -128,7 +128,7 @@ object FireAlertsDF {
     val confCols = if (!aggCol.equals("burned_area__ha")) List($"confidence__cat")  else List()
 
     val fireCols = List(
-      year($"alert__date") as "alert__year",
+      expr("EXTRACT(YEAROFWEEK FROM alert__date)") as "alert__year",
       weekofyear($"alert__date") as "alert__week",
     ) ::: confCols
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type


Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
For extracting alert__week from alert__date in the VIIRS analysis, we use a function that returns the iso week. The iso week can sometimes extend across years to keep week definitions consistent (e.g. December 2020 has a week 53 that extends into January 2021). 

For the corresponding alert__year value, we're using a normal year function, not the iso year function. So in the case above, January 1st 2021 will return 2021 instead of 2020. So the date will be return as week 53 of 2021, when it should be week 53 of 2020.

Issue Number: GTC-2644


## What is the new behavior?
Use a new extraction function that gets the iso year from the date.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

