### PR TITLE
Eliminate extra call to RasterExtent by reusing it to calculate cellSize

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticSummary.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticSummary.scala
@@ -55,8 +55,11 @@ object ForestChangeDiagnosticSummary {
         // This is a pixel by pixel operation
 
         // pixel Area
-        val lat: Double = raster.rasterExtent.gridRowToMap(row)
-        val area: Double = Geodesy.pixelArea(lat, raster.cellSize) // uses Pixel's center coordiate.  +- raster.cellSize.height/2 doesn't make much of a difference
+        val re: RasterExtent = raster.rasterExtent
+        val lat: Double = re.gridRowToMap(row)
+        // uses Pixel's center coordinate. +/- raster.cellSize.height/2
+        // doesn't make much of a difference
+        val area: Double = Geodesy.pixelArea(lat, re.cellSize)
         val areaHa = area / 10000.0
 
         // input layers

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardSummary.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardSummary.scala
@@ -47,7 +47,8 @@ object GfwProDashboardSummary {
         val summaryData = acc.stats.getOrElse(groupKey, GfwProDashboardRawData(treeCoverExtentArea = 0.0, alertCount = 0))
 
         if (isTreeCoverExtent30) {
-          val areaHa = Geodesy.pixelArea(lat = raster.rasterExtent.gridRowToMap(row), raster.cellSize) / 10000.0
+          val re: RasterExtent = raster.rasterExtent
+          val areaHa = Geodesy.pixelArea(lat = re.gridRowToMap(row), re.cellSize) / 10000.0
           summaryData.treeCoverExtentArea += areaHa
         }
 


### PR DESCRIPTION
Eliminate extra call to RasterExtent by reusing same value to calculate cellSize

The rasterExtent, cellSize, and pixelArea calls all show up in profiles of gfwpro_dashboard and forest_change_diagnostic. It totals up to >20% in gfwpro_dashboard for a large area, because there are not a lot of other calculations going on. Eliminating the extra call to rasterExtent inside the cellSize call eliminates at least 5%
