### PR TITLE
Carbon Flux Model v1.3.2 Update

### DIFF
--- a/src/main/resources/raster-catalog-default.json
+++ b/src/main/resources/raster-catalog-default.json
@@ -238,61 +238,61 @@
     },
     {
       "name":"gfw_forest_flux_full_extent_removal_factor_aboveground",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_removal_factor_aboveground/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1_yr-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_removal_factor_aboveground/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1_yr-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_full_extent_removal_factor_belowground",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_removal_factor_belowground/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1_yr-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_removal_factor_belowground/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1_yr-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_full_extent_gross_removals_aboveground",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_removals_aboveground/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2_ha-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_removals_aboveground/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_full_extent_gross_removals_belowground",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_removals_belowground/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2_ha-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_removals_belowground/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_full_extent_gross_emissions_co2_only_biomass_soil",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_emissions_co2_only_biomass_soil/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2_ha-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_emissions_co2_only_biomass_soil/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_full_extent_gross_emissions_non_co2_biomass_soil",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_emissions_non_co2_biomass_soil/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2e_ha-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_emissions_non_co2_biomass_soil/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2e_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_full_extent_gross_emissions_co2_only_soil_only",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_emissions_co2_only_soil_only/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2_ha-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_emissions_co2_only_soil_only/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_full_extent_gross_emissions_non_co2_soil_only",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_emissions_non_co2_soil_only/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2e_ha-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_gross_emissions_non_co2_soil_only/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2e_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_full_extent_net_flux",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_net_flux/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2e_ha-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_full_extent_net_flux/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_CO2e_ha-1/geotiff/{tile_id}.tif"
     },
 
 
     {
       "name":"gfw_forest_flux_aboveground_carbon_stock_in_emissions_year",
-      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_aboveground_carbon_stock_in_emissions_year/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
+      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_aboveground_carbon_stock_in_emissions_year/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_belowground_carbon_stock_in_emissions_year",
-      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_belowground_carbon_stock_in_emissions_year/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
+      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_belowground_carbon_stock_in_emissions_year/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_deadwood_carbon_stock_in_emissions_year",
-      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_deadwood_carbon_stock_in_emissions_year/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
+      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_deadwood_carbon_stock_in_emissions_year/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_litter_carbon_stock_in_emissions_year",
-      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_litter_carbon_stock_in_emissions_year/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
+      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_litter_carbon_stock_in_emissions_year/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_soil_carbon_stock_in_emissions_year",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_soil_carbon_stock_in_emissions_year/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_soil_carbon_stock_in_emissions_year/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_aboveground_carbon_stock_2000",
@@ -321,23 +321,23 @@
     },
     {
       "name":"gfw_forest_flux_removal_factor_aboveground_carbon_stdev",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_removal_factor_aboveground_carbon_stdev/v20231114/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1_yr-1/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_removal_factor_aboveground_carbon_stdev/v20240308/raster/epsg-4326/{grid_size}/{row_count}/Mg_C_ha-1_yr-1/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_model_extent",
-      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_model_extent/v20231114/raster/epsg-4326/{grid_size}/{row_count}/ha/geotiff/{tile_id}.tif"
+      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_model_extent/v20240308/raster/epsg-4326/{grid_size}/{row_count}/ha/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_removal_forest_type",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_removal_forest_type/v20231114/raster/epsg-4326/{grid_size}/{row_count}/source/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_removal_forest_type/v20240308/raster/epsg-4326/{grid_size}/{row_count}/source/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_forest_age_category",
-      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_forest_age_category/v20231114/raster/epsg-4326/{grid_size}/{row_count}/ageCategory/geotiff/{tile_id}.tif"
+      "source_uri":"s3://gfw-data-lake/gfw_forest_flux_forest_age_category/v20240308/raster/epsg-4326/{grid_size}/{row_count}/ageCategory/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_gross_emissions_node_codes",
-      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_gross_emissions_node_codes/v20231114/raster/epsg-4326/{grid_size}/{row_count}/category/geotiff/{tile_id}.tif"
+      "source_uri": "s3://gfw-data-lake/gfw_forest_flux_gross_emissions_node_codes/v20240308/raster/epsg-4326/{grid_size}/{row_count}/category/geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_forest_flux_planted_forest_type",


### PR DESCRIPTION
Updated the uris in the raster-catalog-default.json with the newest versions of the carbon flux model outputs.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Formerly, used the carbon flux model output from version 1.3.1.

Issue Number: N/A


## What is the new behavior?
Changed the uris in the raster-catalog-default.json to use model output from version 1.3.2 (2023 TCL update).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
N/A
