### PR TITLE
GTC-2732 Add JRC map intersection to AFi analysis

### DIFF
--- a/src/main/resources/raster-catalog-pro.json
+++ b/src/main/resources/raster-catalog-pro.json
@@ -263,6 +263,10 @@
     {
       "name":"arg_otbn_forest_loss",
       "source_uri":"s3://gfw-data-lake/arg_otbn_forest_loss/v2022/raster/epsg-4326/{grid_size}/{row_count}/year/gdal-geotiff/{tile_id}.tif"
+    },
+    {
+      "name":"jrc_global_forest_cover",
+      "source_uri":"s3://gfw-data-lake/jrc_global_forest_cover/v2020/raster/epsg-4326/{grid_size}/{row_count}/is/gdal-geotiff/{tile_id}.tif"
     }
   ]
 }

--- a/src/main/scala/org/globalforestwatch/layers/JRCForestCover.scala
+++ b/src/main/scala/org/globalforestwatch/layers/JRCForestCover.scala
@@ -1,0 +1,11 @@
+package org.globalforestwatch.layers
+
+import org.globalforestwatch.grids.GridTile
+
+case class JRCForestCover(gridTile: GridTile, kwargs: Map[String, Any])
+    extends BooleanLayer
+        with OptionalILayer {
+
+    val datasetName = "jrc_global_forest_cover"
+    val uri: String = uriForGrid(gridTile, kwargs)
+}

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiAnalysis.scala
@@ -73,6 +73,8 @@ object AFiAnalysis extends SummaryAnalysis {
     group.agg(
         sum("natural_forest__extent").alias("natural_forest__extent"),
         sum("natural_forest_loss__ha").alias("natural_forest_loss__ha"),
+        sum("jrc_forest_cover__extent").alias("jrc_forest_cover__extent"),
+        sum("jrc_forest_cover_loss__ha").alias("jrc_forest_cover_loss__ha"),
         sum("negligible_risk_area__ha").alias("negligible_risk_area__ha"),
         sum("total_area__ha").alias("total_area__ha"),
         max("status_code").alias("status_code"),

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiData.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiData.scala
@@ -9,6 +9,8 @@ import cats.Semigroup
 case class AFiData(
                     var natural_forest__extent: Double,
                     var natural_forest_loss__ha: Double,
+                    var jrc_forest_cover__extent: Double,
+                    var jrc_forest_cover_loss__ha: Double,
                     var negligible_risk_area__ha: Double,
                     var total_area__ha: Double
                   ) {
@@ -16,6 +18,8 @@ case class AFiData(
     AFiData(
       natural_forest__extent + other.natural_forest__extent,
       natural_forest_loss__ha + other.natural_forest_loss__ha,
+      jrc_forest_cover__extent + other.jrc_forest_cover__extent,
+      jrc_forest_cover_loss__ha + other.jrc_forest_cover_loss__ha,
       negligible_risk_area__ha + other.negligible_risk_area__ha,
       total_area__ha + other.total_area__ha
     )
@@ -24,7 +28,7 @@ case class AFiData(
 
 object AFiData {
   def empty: AFiData =
-    AFiData(0, 0, 0, 0)
+    AFiData(0, 0, 0, 0, 0, 0)
 
   implicit val afiDataSemigroup: Semigroup[AFiData] =
     new Semigroup[AFiData] {

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiGrid.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiGrid.scala
@@ -1,10 +1,11 @@
 package org.globalforestwatch.summarystats.afi
 
 import geotrellis.vector.Extent
-import org.globalforestwatch.grids.{GridTile, TenByTen30mGrid}
+import org.globalforestwatch.grids.{GridTile, TenByTen10mGrid}
 
 object AFiGrid
-  extends TenByTen30mGrid[AFiGridSources] {
+  // Using 10m grid, since the native resolution of JRC map is around 10m.
+  extends TenByTen10mGrid[AFiGridSources] {
 
   val gridExtent: Extent = Extent(-180.0000, -90.0000, 180.0000, 90.0000)
 

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiGridSources.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiGridSources.scala
@@ -16,6 +16,7 @@ case class AFiGridSources(gridTile: GridTile, kwargs: Map[String, Any]) extends 
   val gadmAdm0: GadmAdm0 = GadmAdm0(gridTile, kwargs)
   val gadmAdm1: GadmAdm1 = GadmAdm1(gridTile, kwargs)
   val gadmAdm2: GadmAdm2 = GadmAdm2(gridTile, kwargs)
+  val jrcForestCover: JRCForestCover = JRCForestCover(gridTile, kwargs)
 
   def readWindow(
     windowKey: SpatialKey,
@@ -30,6 +31,7 @@ case class AFiGridSources(gridTile: GridTile, kwargs: Map[String, Any]) extends 
       val adm0Tile = gadmAdm0.fetchWindow(windowKey, windowLayout)
       val adm1Tile = gadmAdm1.fetchWindow(windowKey, windowLayout)
       val adm2Tile = gadmAdm2.fetchWindow(windowKey, windowLayout)
+      val jrcForestCoverTile = jrcForestCover.fetchWindow(windowKey, windowLayout)
 
       val tile = AFiTile(
         lossTile,
@@ -37,7 +39,8 @@ case class AFiGridSources(gridTile: GridTile, kwargs: Map[String, Any]) extends 
         negligibleRiskTile,
         adm0Tile,
         adm1Tile,
-        adm2Tile
+        adm2Tile,
+        jrcForestCoverTile
       )
       Raster(tile, windowKey.extent(windowLayout))
     }

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiTile.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiTile.scala
@@ -1,6 +1,6 @@
 package org.globalforestwatch.summarystats.afi
 
-import geotrellis.raster.{CellGrid, CellType, IntCellType}
+import geotrellis.raster.{CellGrid, CellType}
 import org.globalforestwatch.layers._
 
 /**
@@ -14,7 +14,8 @@ case class AFiTile(
   negligibleRisk: NegligibleRisk#OptionalITile,
   gadmAdm0: GadmAdm0#OptionalITile,
   gadmAdm1: GadmAdm1#OptionalITile,
-  gadmAdm2: GadmAdm2#OptionalITile
+  gadmAdm2: GadmAdm2#OptionalITile,
+  jrcForestCover: JRCForestCover#OptionalITile
 ) extends CellGrid[Int] {
 
   def cellType: CellType = treeCoverLoss.cellType

--- a/src/test/resources/palm-32-afi-output/part-00000-ab565f13-95b4-475b-b190-46332d027eb2-c000.csv
+++ b/src/test/resources/palm-32-afi-output/part-00000-ab565f13-95b4-475b-b190-46332d027eb2-c000.csv
@@ -1,0 +1,2 @@
+list_id	location_id	gadm_id	natural_forest__extent	natural_forest_loss__ha	jrc_forest_cover__extent	jrc_forest_cover_loss__ha	total_area__ha	status_code	location_error	negligible_risk__percent
+1	31		19553.39576352953	319.8536911536501	31135.74247274201	709.285699546162	125582.7220359901	2		0.0

--- a/src/test/resources/palm-32-afi-output/part-00000-cf173020-47f1-4ca7-8045-620c18c2a47f-c000.csv
+++ b/src/test/resources/palm-32-afi-output/part-00000-cf173020-47f1-4ca7-8045-620c18c2a47f-c000.csv
@@ -1,2 +1,0 @@
-list_id	location_id	gadm_id	natural_forest__extent	natural_forest_loss__ha	total_area__ha	status_code	location_error	negligible_risk__percent
-1	31		19553.415753078054	319.6415718021263	125583.72840131013	2		0.0


### PR DESCRIPTION
GTC-2732 Add JRC map intersection to AFi analysis

The native JRC map is close to 10m resolution, so we move the grid and all the other datasets to 10m resolution. JRC is the more official forest cover map for EUDR vs. the SBTN natural forests map. Added two new columns in the output, jrc_forest_cover__extent and jrc_forest_cover_loss__ha, in analogy to the natural_forest_* columns.
