### PR TITLE
Change  "LT-snapshots" resolver to repo.eclipse.org

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ addCompilerPlugin(
 resolvers ++= Seq(
   "GeoSolutions" at "https://maven.geo-solutions.it/",
   "LT-releases" at "https://repo.locationtech.org/content/groups/releases",
-  "LT-snapshots" at "https://repo.locationtech.org/content/groups/snapshots",
+  "LT-snapshots" at "https://repo.eclipse.org/content/groups/snapshots",
   "OSGeo" at "https://repo.osgeo.org/repository/release/",
   "Open Source Geospatial Foundation Repository" at "https://repo.osgeo.org/repository/release/",
   "Apache Software Foundation Snapshots" at "https://repository.apache.org/content/groups/snapshots",


### PR DESCRIPTION
Change  "LT-snapshots" resolver to repo.eclipse.org (from repo.locationtech.org)

This is to deal with the problem tha Geotrellis 3.7.0-SNAPSHOT was removed from one of the repos yesterday (maybe from https://repo.locationtech.org/content/groups/snapshots).

This was the solution suggested by Justin Polchlopek and seems to work fine.
