### PR TITLE
Change AFi analysis to round all double results to 4 decimal places.

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiAnalysis.scala
@@ -95,6 +95,12 @@ object AFiAnalysis extends SummaryAnalysis {
     resultsDF
       .withColumn("list_id", col("list_id").cast(IntegerType))
       .withColumn("location_id", col("location_id").cast(IntegerType))
+      .withColumn("natural_forest__extent", round($"natural_forest__extent", 4))
+      .withColumn("natural_forest_loss__ha", round($"natural_forest_loss__ha", 4))
+      .withColumn("jrc_forest_cover__extent", round($"jrc_forest_cover__extent", 4))
+      .withColumn("jrc_forest_cover_loss__ha", round($"jrc_forest_cover_loss__ha", 4))
+      .withColumn("total_area__ha", round($"total_area__ha", 4))
+      .withColumn("negligible_risk__percent", round($"negligible_risk__percent", 4))
   }
 
   // Aggregate all entries with same (list_id, location_id, gadm_id, loss_year)
@@ -115,10 +121,10 @@ object AFiAnalysis extends SummaryAnalysis {
     group.agg(
         sum("natural_forest__extent").alias("natural_forest__extent"),
         sum(when(col("loss_year") =!= 0, col("natural_forest__extent")).otherwise(0.0)).alias("natural_forest_loss__ha"),
-        map_from_arrays(collect_list(when(col("loss_year") =!= 0, col("loss_year"))), collect_list(when(col("loss_year") =!= 0, col("natural_forest__extent")))).alias("natural_forest_loss_by_year__ha"),
+        map_from_arrays(collect_list(when(col("loss_year") =!= 0, col("loss_year"))), collect_list(when(col("loss_year") =!= 0, round(col("natural_forest__extent"), 4)))).alias("natural_forest_loss_by_year__ha"),
         sum("jrc_forest_cover__extent").alias("jrc_forest_cover__extent"),
         sum(when(col("loss_year") =!= 0, col("jrc_forest_cover__extent")).otherwise(0.0)).alias("jrc_forest_cover_loss__ha"),
-        map_from_arrays(collect_list(when(col("loss_year") =!= 0, col("loss_year"))), collect_list(when(col("loss_year") =!= 0, col("jrc_forest_cover__extent")))).alias("jrc_forest_loss_by_year__ha"),
+        map_from_arrays(collect_list(when(col("loss_year") =!= 0, col("loss_year"))), collect_list(when(col("loss_year") =!= 0, round(col("jrc_forest_cover__extent"), 4)))).alias("jrc_forest_loss_by_year__ha"),
         sum("negligible_risk_area__ha").alias("negligible_risk_area__ha"),
         sum("total_area__ha").alias("total_area__ha"),
         max("status_code").alias("status_code"),

--- a/src/test/resources/palm-32-afi-output/part-00000-a22db371-07a5-44f3-a406-818ce50afca4-c000.csv
+++ b/src/test/resources/palm-32-afi-output/part-00000-a22db371-07a5-44f3-a406-818ce50afca4-c000.csv
@@ -1,0 +1,2 @@
+list_id	location_id	gadm_id	natural_forest__extent	natural_forest_loss__ha	natural_forest_loss_by_year__ha	jrc_forest_cover__extent	jrc_forest_cover_loss__ha	jrc_forest_loss_by_year__ha	total_area__ha	status_code	location_error	negligible_risk__percent
+1	31		19553.3958	485.8991	{"2021":181.7124,"2022":138.1413,"2023":166.0455}	31135.7425	1182.3486	{"2021":346.5172,"2022":362.7685,"2023":473.0629}	125582.722	2		0.0

--- a/src/test/resources/palm-32-afi-output/part-00000-e0064552-036e-4373-ab16-ad8ef42822f8-c000.csv
+++ b/src/test/resources/palm-32-afi-output/part-00000-e0064552-036e-4373-ab16-ad8ef42822f8-c000.csv
@@ -1,2 +1,0 @@
-list_id	location_id	gadm_id	natural_forest__extent	natural_forest_loss__ha	natural_forest_loss_by_year__ha	jrc_forest_cover__extent	jrc_forest_cover_loss__ha	jrc_forest_loss_by_year__ha	total_area__ha	status_code	location_error	negligible_risk__percent
-1	31		19553.39576352615	485.89914956638154	{"2021":181.7123592654985,"2022":138.14133188815134,"2023":166.0454584127317}	31135.74247273864	1182.3485958452038	{"2021":346.5171931123645,"2022":362.7685064338093,"2023":473.06289629902983}	125582.72203599932	2		0.0


### PR DESCRIPTION
Change AFi analysis to round all double results to 4 decimal places.

Because AFi analysis was written with most of the computations done in DataFrames, it never did the rounding to 4 decimal places that FCD and Dashboard do (which is built into their data types such as ForestChangeDiagnosticDataDouble and
ForestChangeDiagnosticDataLossYearly).

The rounding is useful for making sure test results match even when running in slightly different environments. Also, it makes the CSV files simpler, since GFWPro doesn't need any values to more than 4 decimal places, but AFi was giving results with up to 13 decimal places.
