### PR TITLE
Reduce calls to Data API for GFWPro analyses

### DIFF
--- a/src/main/resources/raster-catalog-pro.json
+++ b/src/main/resources/raster-catalog-pro.json
@@ -197,10 +197,6 @@
       "source_uri":"s3://gfw-data-lake/gfwpro_peatlands/v2019/raster/epsg-4326/{grid_size}/{row_count}/is/gdal-geotiff/{tile_id}.tif"
     },
     {
-      "name":"umd_glad_landsat_alerts",
-      "source_uri":"s3://gfw-data-lake/umd_glad_landsat_alerts/latest/raster/epsg-4326/{grid_size}/{row_count}/date_conf/gdal-geotiff/{tile_id}.tif"
-    },
-    {
       "name":"gfw_plantations",
       "source_uri":"s3://gfw-data-lake/gfw_plantations/v1.3/raster/epsg-4326/{grid_size}/{row_count}/type/gdal-geotiff/{tile_id}.tif"
     },

--- a/src/main/scala/org/globalforestwatch/config/RasterCatalog.scala
+++ b/src/main/scala/org/globalforestwatch/config/RasterCatalog.scala
@@ -75,12 +75,14 @@ object RasterCatalog {
   // recursively as necessary. Return the JSON response. Throws an exception if there
   // was no successful response.
   def getLatestVersionResponse(dataset: String, retries: Int = 0): HttpResponse[String] = {
+    println("Sending data API 'latest' request")
     val response: HttpResponse[String] = Http(
       s"https://data-api.globalforestwatch.org/dataset/${dataset}/latest"
     ).option(HttpOptions
       .followRedirects(true))
       .option(HttpOptions.connTimeout(20000))
       .option(HttpOptions.readTimeout(50000)).asString
+    println("Got data API response")
 
     if (response.isSuccess) {
       response
@@ -90,6 +92,7 @@ object RasterCatalog {
         s"Problem accessing latest version of dataset ${dataset}. Data API response code: ${response.code}"
       )
     } else {
+      println(s"Retrying after problem accessing latest version of dataset ${dataset}. Data API response code: ${response.code}")
       // Sleep for ten seconds and then return any successful retry.
       Thread.sleep(10000)
       getLatestVersionResponse(dataset, retries + 1)

--- a/src/main/scala/org/globalforestwatch/summarystats/SummaryMain.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/SummaryMain.scala
@@ -11,12 +11,10 @@ import org.globalforestwatch.summarystats.treecoverloss.TreeCoverLossCommand.tre
 import org.globalforestwatch.summarystats.integrated_alerts.IntegratedAlertsCommand.integratedAlertsCommand
 import org.globalforestwatch.summarystats.afi.AFiCommand.afiCommand
 import com.monovore.decline._
-import org.globalforestwatch.config.GfwConfig
 
 object SummaryMain {
   val name = "geotrellis-summary-stats"
   val header = "Compute summary statistics for GFW data"
-  val config = GfwConfig.get()
   val main = {
     annualupdateMinimalCommand orElse
       carbonSensitivityCommand orElse

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiCommand.scala
@@ -7,7 +7,8 @@ import org.globalforestwatch.config.GfwConfig
 import org.globalforestwatch.features._
 import org.globalforestwatch.summarystats.afi.AFiAnalysis.getOutputUrl
 import cats.data.Validated.Valid
-
+import org.globalforestwatch.util.Config
+import cats.data.NonEmptyList
 
 object AFiCommand extends SummaryCommand {
   // Current range of years for UMD tree cover loss to include and break out during AFi analysis.
@@ -26,7 +27,8 @@ object AFiCommand extends SummaryCommand {
         "outputUrl" -> default.outputUrl,
         "noOutputPathSuffix" -> default.noOutputPathSuffix,
         "overwriteOutput" -> default.overwriteOutput,
-        "config" -> GfwConfig.get()
+        // Pin the version of gfw_integrated_alerts, so we don't make a data API request for 'latest'
+        "config" -> GfwConfig.get(Some(NonEmptyList.one(Config("gfw_integrated_alerts", "v20231121"))))
       )
       val featureFilter = FeatureFilter.fromOptions(default.featureType, filterOptions)
 

--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticCommand.scala
@@ -9,6 +9,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.globalforestwatch.summarystats.ValidatedLocation
 import org.apache.spark.rdd.RDD
 import org.globalforestwatch.config.GfwConfig
+import org.globalforestwatch.util.Config
 
 object ForestChangeDiagnosticCommand extends SummaryCommand with LazyLogging {
   // Current range of years for UMD tree cover loss and country-specific tree cover loss.
@@ -37,7 +38,8 @@ object ForestChangeDiagnosticCommand extends SummaryCommand with LazyLogging {
         "outputUrl" -> default.outputUrl,
         "noOutputPathSuffix" -> default.noOutputPathSuffix,
         "overwriteOutput" -> default.overwriteOutput,
-        "config" -> GfwConfig.get()
+        // Pin the version of gfw_integrated_alerts, so we don't make a data API request for 'latest'
+        "config" -> GfwConfig.get(Some(NonEmptyList.one(Config("gfw_integrated_alerts", "v20231121"))))
       )
 
       if (!default.splitFeatures) logger.warn("Forcing splitFeatures = true")

--- a/src/test/scala/org/globalforestwatch/layers/GladAlertsSuite.scala
+++ b/src/test/scala/org/globalforestwatch/layers/GladAlertsSuite.scala
@@ -12,7 +12,9 @@ class GladAlertsSuits extends AnyFunSuite {
 
   private val fullDate = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
-  val glad = new GladAlerts(GridTile(10, 40000, 400, "10N_010E"), Map("config" -> GfwConfig.get()))
+  // Don't do GladAlerts initialization unless we are really running a DefaultTag test,
+  // since we don't have glad_alerts dataset in Pro's raster-catalog-pro.json file.
+  lazy val glad = new GladAlerts(GridTile(10, 40000, 400, "10N_010E"), Map("config" -> GfwConfig.get()))
 
   test("Unconfirmed date 1", DefaultTag) {
     assert(


### PR DESCRIPTION
Reduce calls to Data API for GFWPro analyses

The result of the following changes is that we now only call the data API exactly once for GFWPro dashboard analyses (previously four times), and we no longer call the data API at all for the FCD and AFi analyses.

 - Remove umd_glad_landsat_alerts entry from the raster-catalog-pro.json. It is not used for GFWPro analyses (only integrated alerts is used for Dashboard), but causes a Data API call because of its use of 'latest'. I needed to adjust GladAlertsSuites, so it create GladAlerts() lazily, since that class is initialized even during GFWPro test runs.

 - Removed redundant call to GfwConfig.get() in SummaryMain.scala. I'm not sure why this is here (it's been in for a while), since all the analyses have their own call to GfwConfig.get(). Maybe this was for debugging and mistakenly left in?

 - Make use of pinning versions that I added for the dashboard tests. For the FCD and AFi analyses, I supply config option to pin the version of gfw_integrated_alerts, since these analyses don't need to access integrated alerts, and the pinning means we won't call the data API to get the latest version.
