### PR TITLE
GTC-2830 Add WDPA and Landmark overlap to AFI

### DIFF
--- a/src/main/resources/raster-catalog-pro.json
+++ b/src/main/resources/raster-catalog-pro.json
@@ -14,7 +14,7 @@
     },
     {
       "name":"detailed_wdpa_protected_areas",
-      "source_uri":"s3://gfw-data-lake/wdpa_licensed_protected_areas/v202402/raster/epsg-4326/{grid_size}/{row_count}/detailed_iucn_cat/gdal-geotiff/{tile_id}.tif"
+      "source_uri":"s3://gfw-data-lake/wdpa_licensed_protected_areas/v202405/raster/epsg-4326/{grid_size}/{row_count}/detailed_iucn_cat/gdal-geotiff/{tile_id}.tif"
     },
     {
       "name":"gfw_oil_gas",

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiAnalysis.scala
@@ -99,6 +99,8 @@ object AFiAnalysis extends SummaryAnalysis {
       .withColumn("natural_forest_loss__ha", round($"natural_forest_loss__ha", 4))
       .withColumn("jrc_forest_cover__extent", round($"jrc_forest_cover__extent", 4))
       .withColumn("jrc_forest_cover_loss__ha", round($"jrc_forest_cover_loss__ha", 4))
+      .withColumn("protected_areas_area__ha", round($"protected_areas_area__ha", 4))
+      .withColumn("landmark_area__ha", round($"landmark_area__ha", 4))
       .withColumn("total_area__ha", round($"total_area__ha", 4))
       .withColumn("negligible_risk__percent", round($"negligible_risk__percent", 4))
   }
@@ -109,6 +111,8 @@ object AFiAnalysis extends SummaryAnalysis {
         sum("natural_forest__extent").alias("natural_forest__extent"),
         sum("jrc_forest_cover__extent").alias("jrc_forest_cover__extent"),
         sum("negligible_risk_area__ha").alias("negligible_risk_area__ha"),
+        sum("protected_areas_area__ha").alias("protected_areas_area__ha"),
+        sum("landmark_area__ha").alias("landmark_area__ha"),
         sum("total_area__ha").alias("total_area__ha"),
         max("status_code").alias("status_code"),
         concat_ws(", ", collect_list(when(col("location_error").isNotNull && col("location_error") =!= "", col("location_error")))).alias("location_error")
@@ -126,6 +130,8 @@ object AFiAnalysis extends SummaryAnalysis {
         sum(when(col("loss_year") =!= 0, col("jrc_forest_cover__extent")).otherwise(0.0)).alias("jrc_forest_cover_loss__ha"),
         map_from_arrays(collect_list(when(col("loss_year") =!= 0, col("loss_year"))), collect_list(when(col("loss_year") =!= 0, round(col("jrc_forest_cover__extent"), 4)))).alias("jrc_forest_loss_by_year__ha"),
         sum("negligible_risk_area__ha").alias("negligible_risk_area__ha"),
+        sum("protected_areas_area__ha").alias("protected_areas_area__ha"),
+        sum("landmark_area__ha").alias("landmark_area__ha"),
         sum("total_area__ha").alias("total_area__ha"),
         max("status_code").alias("status_code"),
         concat_ws(", ", collect_list(when(col("location_error").isNotNull && col("location_error") =!= "", col("location_error")))).alias("location_error")

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiData.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiData.scala
@@ -10,6 +10,8 @@ case class AFiData(
                     var natural_forest__extent: Double,
                     var jrc_forest_cover__extent: Double,
                     var negligible_risk_area__ha: Double,
+                    var protected_areas_area__ha: Double,
+                    var landmark_area__ha: Double,
                     var total_area__ha: Double
                   ) {
   def merge(other: AFiData): AFiData = {
@@ -17,6 +19,8 @@ case class AFiData(
       natural_forest__extent + other.natural_forest__extent,
       jrc_forest_cover__extent + other.jrc_forest_cover__extent,
       negligible_risk_area__ha + other.negligible_risk_area__ha,
+      protected_areas_area__ha + other.protected_areas_area__ha,
+      landmark_area__ha + other.landmark_area__ha,
       total_area__ha + other.total_area__ha
     )
   }
@@ -24,7 +28,7 @@ case class AFiData(
 
 object AFiData {
   def empty: AFiData =
-    AFiData(0, 0, 0, 0)
+    AFiData(0, 0, 0, 0, 0, 0)
 
   implicit val afiDataSemigroup: Semigroup[AFiData] =
     new Semigroup[AFiData] {

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiGridSources.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiGridSources.scala
@@ -17,6 +17,8 @@ case class AFiGridSources(gridTile: GridTile, kwargs: Map[String, Any]) extends 
   val gadmAdm1: GadmAdm1 = GadmAdm1(gridTile, kwargs)
   val gadmAdm2: GadmAdm2 = GadmAdm2(gridTile, kwargs)
   val jrcForestCover: JRCForestCover = JRCForestCover(gridTile, kwargs)
+  val detailedProtectedAreas: DetailedProtectedAreas = DetailedProtectedAreas(gridTile, kwargs)
+  val landmark: Landmark = Landmark(gridTile, kwargs)
 
   def readWindow(
     windowKey: SpatialKey,
@@ -32,6 +34,8 @@ case class AFiGridSources(gridTile: GridTile, kwargs: Map[String, Any]) extends 
       val adm1Tile = gadmAdm1.fetchWindow(windowKey, windowLayout)
       val adm2Tile = gadmAdm2.fetchWindow(windowKey, windowLayout)
       val jrcForestCoverTile = jrcForestCover.fetchWindow(windowKey, windowLayout)
+      val detailedProtectedAreasTile = detailedProtectedAreas.fetchWindow(windowKey, windowLayout)
+      val landmarkTile = landmark.fetchWindow(windowKey, windowLayout)
 
       val tile = AFiTile(
         lossTile,
@@ -40,7 +44,9 @@ case class AFiGridSources(gridTile: GridTile, kwargs: Map[String, Any]) extends 
         adm0Tile,
         adm1Tile,
         adm2Tile,
-        jrcForestCoverTile
+        jrcForestCoverTile,
+        detailedProtectedAreasTile,
+        landmarkTile
       )
       Raster(tile, windowKey.extent(windowLayout))
     }

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiSummary.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiSummary.scala
@@ -36,6 +36,8 @@ object AFiSummary {
         val naturalForestCategory: String = raster.tile.sbtnNaturalForest.getData(col, row)
         val negligibleRisk: String = raster.tile.negligibleRisk.getData(col, row)
         val jrcForestCover: Boolean = raster.tile.jrcForestCover.getData(col, row)
+        val protectedArea: Boolean = raster.tile.detailedProtectedAreas.getData(col, row) != ""
+        val landmark: Boolean = raster.tile.landmark.getData(col, row)
 
         val gadmAdm0: String = raster.tile.gadmAdm0.getData(col, row)
         // Skip processing this pixel if gadmAdm0 is empty
@@ -58,7 +60,7 @@ object AFiSummary {
 
 
         val groupKey = AFiDataGroup(gadmId, lossYearClipped)
-        val summaryData = acc.stats.getOrElse(groupKey, AFiData(0, 0, 0, 0))
+        val summaryData = acc.stats.getOrElse(groupKey, AFiData(0, 0, 0, 0, 0, 0))
         summaryData.total_area__ha += areaHa
 
         if (negligibleRisk == "YES") {
@@ -73,6 +75,13 @@ object AFiSummary {
           summaryData.jrc_forest_cover__extent += areaHa
         }
 
+        if (protectedArea) {
+          summaryData.protected_areas_area__ha += areaHa
+        }
+
+        if (landmark) {
+          summaryData.landmark_area__ha += areaHa
+        }
         val new_stats = acc.stats.updated(groupKey, summaryData)
         acc = AFiSummary(new_stats)
       }

--- a/src/main/scala/org/globalforestwatch/summarystats/afi/AFiTile.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/afi/AFiTile.scala
@@ -15,7 +15,9 @@ case class AFiTile(
   gadmAdm0: GadmAdm0#OptionalITile,
   gadmAdm1: GadmAdm1#OptionalITile,
   gadmAdm2: GadmAdm2#OptionalITile,
-  jrcForestCover: JRCForestCover#OptionalITile
+  jrcForestCover: JRCForestCover#OptionalITile,
+  detailedProtectedAreas: DetailedProtectedAreas#OptionalITile,
+  landmark: Landmark#OptionalITile
 ) extends CellGrid[Int] {
 
   def cellType: CellType = treeCoverLoss.cellType

--- a/src/test/resources/palm-32-afi-output/part-00000-6e099ea3-1c55-44d9-9d9e-4e5f3eb30723-c000.csv
+++ b/src/test/resources/palm-32-afi-output/part-00000-6e099ea3-1c55-44d9-9d9e-4e5f3eb30723-c000.csv
@@ -1,2 +1,4 @@
 list_id	location_id	gadm_id	natural_forest__extent	natural_forest_loss__ha	natural_forest_loss_by_year__ha	jrc_forest_cover__extent	jrc_forest_cover_loss__ha	jrc_forest_loss_by_year__ha	protected_areas_area__ha	landmark_area__ha	total_area__ha	status_code	location_error	negligible_risk__percent
+1	-1	IDN.14.7	19553.3958	485.8991	{"2021":181.7124,"2022":138.1413,"2023":166.0455}	31135.7425	1182.3486	{"2021":346.5172,"2022":362.7685,"2023":473.0629}	0.0	0.0	125582.722	2		0.0
 1	31		19553.3958	485.8991	{"2021":181.7124,"2022":138.1413,"2023":166.0455}	31135.7425	1182.3486	{"2021":346.5172,"2022":362.7685,"2023":473.0629}	0.0	0.0	125582.722	2		0.0
+1	-1		19553.3958	485.8991	{"2021":181.7124,"2022":138.1413,"2023":166.0455}	31135.7425	1182.3486	{"2021":346.5172,"2022":362.7685,"2023":473.0629}	0.0	0.0	125582.722	2		0.0

--- a/src/test/resources/palm-32-afi-output/part-00000-a02553a9-9596-42f8-b8b5-478c6b369db8-c000.csv
+++ b/src/test/resources/palm-32-afi-output/part-00000-a02553a9-9596-42f8-b8b5-478c6b369db8-c000.csv
@@ -1,0 +1,2 @@
+list_id	location_id	gadm_id	natural_forest__extent	natural_forest_loss__ha	natural_forest_loss_by_year__ha	jrc_forest_cover__extent	jrc_forest_cover_loss__ha	jrc_forest_loss_by_year__ha	protected_areas_area__ha	landmark_area__ha	total_area__ha	status_code	location_error	negligible_risk__percent
+1	31		19553.3958	485.8991	{"2021":181.7124,"2022":138.1413,"2023":166.0455}	31135.7425	1182.3486	{"2021":346.5172,"2022":362.7685,"2023":473.0629}	0.0	0.0	125582.722	2		0.0

--- a/src/test/resources/palm-32-afi-output/part-00000-a22db371-07a5-44f3-a406-818ce50afca4-c000.csv
+++ b/src/test/resources/palm-32-afi-output/part-00000-a22db371-07a5-44f3-a406-818ce50afca4-c000.csv
@@ -1,2 +1,0 @@
-list_id	location_id	gadm_id	natural_forest__extent	natural_forest_loss__ha	natural_forest_loss_by_year__ha	jrc_forest_cover__extent	jrc_forest_cover_loss__ha	jrc_forest_loss_by_year__ha	total_area__ha	status_code	location_error	negligible_risk__percent
-1	31		19553.3958	485.8991	{"2021":181.7124,"2022":138.1413,"2023":166.0455}	31135.7425	1182.3486	{"2021":346.5172,"2022":362.7685,"2023":473.0629}	125582.722	2		0.0


### PR DESCRIPTION
GTC-2830 Add WDPA and Landmark overlap to AFI

Adds new columns "protected_areas_area__ha" and "landmark_area__ha" with
overlap of WDPA and Landmark (single area value, no categories) for each
location and for the per-gadm dissolved list and the total dissolved
list.

I also did GTC-2832 - use May 2024 licensed WDPA in the GFWPro
Geotrellis analyses.

I also improved the AFi test slightly, by adding in an extra "dissolved list" row,
which means the GADM location code is being exercised.
