### PR TITLE
GTC-2859 GPV-3183 Compute centroid for dashboard locations before 1x1 splitting

### DIFF
--- a/src/main/scala/org/globalforestwatch/features/PointFeatureId.scala
+++ b/src/main/scala/org/globalforestwatch/features/PointFeatureId.scala
@@ -1,0 +1,5 @@
+package org.globalforestwatch.features
+
+import org.locationtech.jts.geom.Point
+
+case class PointFeatureId(pt: Point) extends FeatureId

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardCommand.scala
@@ -46,7 +46,7 @@ object GfwProDashboardCommand extends SummaryCommand {
       val featureFilter = FeatureFilter.fromOptions(default.featureType, filterOptions)
 
       runAnalysis { implicit spark =>
-        val featureRDD = ValidatedFeatureRDD(default.featureUris, default.featureType, featureFilter, default.splitFeatures)
+        val featureRDD = ValidatedFeatureRDD(default.featureUris, default.featureType, featureFilter, default.splitFeatures, gfwProAddCentroid = true)
 
         val fireAlertRDD = fireAlert.alertSource match {
           case Some(alertSource) =>

--- a/src/test/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardAnalysisSpec.scala
+++ b/src/test/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardAnalysisSpec.scala
@@ -66,7 +66,8 @@ class GfwProDashboardAnalysisSpec extends TestEnvironment with DataFrameComparer
       NonEmptyList.one(dashInputTsvPath),
       "gfwpro",
       FeatureFilter.empty,
-      splitFeatures = true
+      splitFeatures = true,
+      gfwProAddCentroid = true
     )
     val fcd = Dashboard(featureLoc31RDD)
     val summaryDF = GfwProDashboardDF.getFeatureDataFrameFromVerifiedRdd(fcd.unify, spark)


### PR DESCRIPTION
GTC-2859 GPV-3183 Compute centroid for dashboard locations before 1x1 splitting

We currently compute the centroid of GFWPro locations (locId != -1) after we do 1x1 splitting. This means that if a location (locId != -1) is split into two or more pieces, then we will compute centroids for each piece of the location, and therefore may have two or more rows for the location with different GADM ids. This is not correct - we want only one row per location, with a single GADM id based on the centroid of the overall location. As far as I can tell, this bug has existed since the beginning of the
dashboard analysis.

To fix, I added an optional arg to ValidatedFeatureRDD() to specify that the centroid of locations should be computed and added to their FeatureId before any location is split up. This flag is only set for the GFWProDashboard analysis, which then uses the pre-computed centroid in the FeatureId.
