### PR TITLE
 GTC-2824 Use raster GADM layers for pro dashboard for small # of features

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardDF.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardDF.scala
@@ -2,12 +2,13 @@ package org.globalforestwatch.summarystats.gfwpro_dashboard
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.globalforestwatch.features.{CombinedFeatureId, FeatureId, GadmFeatureId, GfwProFeatureId}
+import org.globalforestwatch.features.{FeatureId, GfwProFeatureId}
 import org.globalforestwatch.summarystats._
 import cats.data.Validated.{Valid, Invalid}
+import org.apache.spark.sql.functions.expr
+import org.globalforestwatch.summarystats.SummaryDF.RowId
 
 object GfwProDashboardDF extends SummaryDF {
-  case class RowGadmId(list_id: String, location_id: String, gadm_id: String)
 
   def getFeatureDataFrameFromVerifiedRdd(
     dataRDD: RDD[ValidatedLocation[GfwProDashboardData]],
@@ -15,11 +16,9 @@ object GfwProDashboardDF extends SummaryDF {
   ): DataFrame = {
     import spark.implicits._
 
-    val rowId: FeatureId => RowGadmId = {
-      case CombinedFeatureId(proId: GfwProFeatureId, gadmId: GadmFeatureId) =>
-        RowGadmId(proId.listId, proId.locationId.toString, gadmId.toString())
+    val rowId: FeatureId => RowId = {
       case proId: GfwProFeatureId =>
-        RowGadmId(proId.listId, proId.locationId.toString, "none")
+        RowId(proId.listId, proId.locationId.toString)
       case _ =>
         throw new IllegalArgumentException("Not a CombinedFeatureId[GfwProFeatureId, GadmFeatureId]")
     }
@@ -30,28 +29,8 @@ object GfwProDashboardDF extends SummaryDF {
         (rowId(id), SummaryDF.RowError.fromJobError(err), GfwProDashboardData.empty)
     }
     .toDF("id", "error", "data")
-    .select($"id.*", $"error.*", $"data.*")
-  }
-
-  def getFeatureDataFrame(
-    dataRDD: RDD[(FeatureId, ValidatedRow[GfwProDashboardData])],
-    spark: SparkSession
-  ): DataFrame = {
-    import spark.implicits._
-
-    dataRDD.mapValues {
-      case Valid(data) =>
-        (SummaryDF.RowError.empty, data)
-      case Invalid(err) =>
-        (SummaryDF.RowError.fromJobError(err), GfwProDashboardData.empty)
-    }.map {
-      case (CombinedFeatureId(proId: GfwProFeatureId, gadmId: GadmFeatureId), (error, data)) =>
-        val rowId = RowGadmId(proId.listId, proId.locationId.toString, gadmId.toString())
-        (rowId, error, data)
-      case _ =>
-        throw new IllegalArgumentException("Not a CombinedFeatureId[GfwProFeatureId, GadmFeatureId]")
-    }
-    .toDF("id", "error", "data")
-    .select($"id.*", $"error.*", $"data.*")
+    // Put data.group_gadm_id right after list/location and rename to gadm_id
+    .select($"id.*", expr("data.group_gadm_id as gadm_id"), $"error.*", $"data.*")
+    .drop($"group_gadm_id")
   }
 }

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardData.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardData.scala
@@ -9,6 +9,9 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
   * Note: This case class contains mutable values
   */
 case class GfwProDashboardData(
+  // Relevant for dissolved locations (locationId == -1)
+  group_gadm_id: String,
+
   /* NOTE: We are temporarily leaving the existing integrated alerts fields named as
    * glad_alerts_*, in order to reduce the number of moving pieces as we move from
    * Glad alerts to integrated alerts in GFWPro. */
@@ -48,6 +51,7 @@ case class GfwProDashboardData(
 
   def merge(other: GfwProDashboardData): GfwProDashboardData = {
     GfwProDashboardData(
+      if (group_gadm_id != "") group_gadm_id else other.group_gadm_id,
       glad_alerts_coverage || other.glad_alerts_coverage,
       integrated_alerts_coverage || other.integrated_alerts_coverage,
       total_ha.merge(other.total_ha),
@@ -73,6 +77,7 @@ object GfwProDashboardData {
 
   def empty: GfwProDashboardData =
     GfwProDashboardData(
+      group_gadm_id = "",
       glad_alerts_coverage = false,
       integrated_alerts_coverage = false,
       total_ha = ForestChangeDiagnosticDataDouble.empty,

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardGridSources.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardGridSources.scala
@@ -22,33 +22,10 @@ case class GfwProDashboardGridSources(gridTile: GridTile, kwargs: Map[String, An
                   windowLayout: LayoutDefinition
                 ): Either[Throwable, Raster[GfwProDashboardTile]] = {
 
-    for {
-      // Integrated alerts are Optional Tiles, but we keep it this way to avoid signature changes
-      integratedAlertsTile <- Either
-        .catchNonFatal(integratedAlerts.fetchWindow(windowKey, windowLayout))
-        .right
-      tcd2000Tile <- Either
-        .catchNonFatal(treeCoverDensity2000.fetchWindow(windowKey, windowLayout))
-        .right
-      sbtnNaturalForestTile <- Either
-        .catchNonFatal(sbtnNaturalForest.fetchWindow(windowKey, windowLayout))
-        .right
-      jrcForestCoverTile <- Either
-        .catchNonFatal(jrcForestCover.fetchWindow(windowKey, windowLayout))
-        .right
-      gadm0Tile <- Either
-        .catchNonFatal(gadmAdm0.fetchWindow(windowKey, windowLayout))
-        .right
-      gadm1Tile <- Either
-        .catchNonFatal(gadmAdm1.fetchWindow(windowKey, windowLayout))
-        .right
-      gadm2Tile <- Either
-        .catchNonFatal(gadmAdm2.fetchWindow(windowKey, windowLayout))
-        .right
-    } yield {
-      val tile = GfwProDashboardTile(integratedAlertsTile, tcd2000Tile, sbtnNaturalForestTile, jrcForestCoverTile, gadm0Tile, gadm1Tile, gadm2Tile)
-      Raster(tile, windowKey.extent(windowLayout))
-    }
+    val tile = GfwProDashboardTile(
+      windowKey, windowLayout, this
+    )
+    Right(Raster(tile, windowKey.extent(windowLayout)))
   }
 }
 

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardGridSources.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardGridSources.scala
@@ -1,6 +1,5 @@
 package org.globalforestwatch.summarystats.gfwpro_dashboard
 
-import cats.implicits._
 import geotrellis.layer.{LayoutDefinition, SpatialKey}
 import geotrellis.raster.Raster
 import org.globalforestwatch.grids.{GridSources, GridTile}
@@ -14,6 +13,9 @@ case class GfwProDashboardGridSources(gridTile: GridTile, kwargs: Map[String, An
   val treeCoverDensity2000 = TreeCoverDensityPercent2000(gridTile, kwargs)
   val sbtnNaturalForest: SBTNNaturalForests = SBTNNaturalForests(gridTile, kwargs)
   val jrcForestCover: JRCForestCover = JRCForestCover(gridTile, kwargs)
+  val gadmAdm0: GadmAdm0 = GadmAdm0(gridTile, kwargs)
+  val gadmAdm1: GadmAdm1 = GadmAdm1(gridTile, kwargs)
+  val gadmAdm2: GadmAdm2 = GadmAdm2(gridTile, kwargs)
 
   def readWindow(
                   windowKey: SpatialKey,
@@ -34,8 +36,17 @@ case class GfwProDashboardGridSources(gridTile: GridTile, kwargs: Map[String, An
       jrcForestCoverTile <- Either
         .catchNonFatal(jrcForestCover.fetchWindow(windowKey, windowLayout))
         .right
+      gadm0Tile <- Either
+        .catchNonFatal(gadmAdm0.fetchWindow(windowKey, windowLayout))
+        .right
+      gadm1Tile <- Either
+        .catchNonFatal(gadmAdm1.fetchWindow(windowKey, windowLayout))
+        .right
+      gadm2Tile <- Either
+        .catchNonFatal(gadmAdm2.fetchWindow(windowKey, windowLayout))
+        .right
     } yield {
-      val tile = GfwProDashboardTile(integratedAlertsTile, tcd2000Tile, sbtnNaturalForestTile, jrcForestCoverTile)
+      val tile = GfwProDashboardTile(integratedAlertsTile, tcd2000Tile, sbtnNaturalForestTile, jrcForestCoverTile, gadm0Tile, gadm1Tile, gadm2Tile)
       Raster(tile, windowKey.extent(windowLayout))
     }
   }

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawDataGroup.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardRawDataGroup.scala
@@ -6,6 +6,7 @@ import java.time.LocalDate
 
 
 case class GfwProDashboardRawDataGroup(
+  groupGadmId: String,
   alertDateAndConf: Option[(LocalDate, Int)],
   integratedAlertsCoverage: Boolean,
   isNaturalForest: Boolean,
@@ -20,6 +21,7 @@ case class GfwProDashboardRawDataGroup(
       }
 
       GfwProDashboardData(
+        group_gadm_id = groupGadmId,
         glad_alerts_coverage = integratedAlertsCoverage,
         integrated_alerts_coverage = integratedAlertsCoverage,
         glad_alerts_daily = GfwProDashboardDataDateCount.fillDaily(alertDate, true, alertCount),

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardTile.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardTile.scala
@@ -12,7 +12,10 @@ case class GfwProDashboardTile(
   integratedAlerts: IntegratedAlerts#OptionalITile,
   tcd2000: TreeCoverDensityPercent2000#ITile,
   sbtnNaturalForest: SBTNNaturalForests#OptionalITile,
-  jrcForestCover: JRCForestCover#OptionalITile
+  jrcForestCover: JRCForestCover#OptionalITile,
+  gadm0: GadmAdm0#OptionalITile,
+  gadm1: GadmAdm1#OptionalITile,
+  gadm2: GadmAdm2#OptionalITile
 ) extends CellGrid[Int] {
 
   def cellType: CellType = integratedAlerts.cellType.getOrElse(IntCellType)

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardTile.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardTile.scala
@@ -1,7 +1,7 @@
 package org.globalforestwatch.summarystats.gfwpro_dashboard
 
 import geotrellis.raster.{CellGrid, CellType, IntCellType}
-import org.globalforestwatch.layers._
+import geotrellis.layer.{LayoutDefinition, SpatialKey}
 
 /**
   *
@@ -9,14 +9,18 @@ import org.globalforestwatch.layers._
   * We can not use GeoTrellis MultibandTile because it requires all bands share a CellType.
   */
 case class GfwProDashboardTile(
-  integratedAlerts: IntegratedAlerts#OptionalITile,
-  tcd2000: TreeCoverDensityPercent2000#ITile,
-  sbtnNaturalForest: SBTNNaturalForests#OptionalITile,
-  jrcForestCover: JRCForestCover#OptionalITile,
-  gadm0: GadmAdm0#OptionalITile,
-  gadm1: GadmAdm1#OptionalITile,
-  gadm2: GadmAdm2#OptionalITile
+  windowKey: SpatialKey,
+  windowLayout: LayoutDefinition,
+  sources: GfwProDashboardGridSources,
 ) extends CellGrid[Int] {
+
+  lazy val integratedAlerts = sources.integratedAlerts.fetchWindow(windowKey, windowLayout)
+  lazy val tcd2000 = sources.treeCoverDensity2000.fetchWindow(windowKey, windowLayout)
+  lazy val sbtnNaturalForest = sources.sbtnNaturalForest.fetchWindow(windowKey, windowLayout)
+  lazy val jrcForestCover = sources.jrcForestCover.fetchWindow(windowKey, windowLayout)
+  lazy val gadm0 = sources.gadmAdm0.fetchWindow(windowKey, windowLayout)
+  lazy val gadm1 = sources.gadmAdm1.fetchWindow(windowKey, windowLayout)
+  lazy val gadm2 = sources.gadmAdm2.fetchWindow(windowKey, windowLayout)
 
   def cellType: CellType = integratedAlerts.cellType.getOrElse(IntCellType)
 


### PR DESCRIPTION
GFWPro Dashboard currently reads in the entire vector GADM file (1.9GB) in order to do a spatial join with the user input features to determine the GADM areas in the input locations and dissolved lists.

Both reading the the GADM file and doing the spatial join can take many minutes, even in the case of a small number of input features. Instead, in that case, we change to using the raster GADM layers to determine the relevant gadm locations for the locations and dissolved lists. Because we lazily read tiles for the GFWPro dashboard (see following commit), we don't read any of the GADM rasters in the case that we are using the vector GADM.

In performance runs, I have seen current batch jobs with 20-50 features that run in 6-9 minutes, but take only about 1 minutes with the same batch configuration when using the raster GADM approach. This should be useful for reducing the cost of the hundreds of batch jobs used to update for the dashboards for all the smaller customer lists every week on Saturday night.