### PR TITLE
GTC-3077 Give NoIntersectionError in AFi if geometry too small

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/forest_change_diagnostic/ForestChangeDiagnosticAnalysis.scala
@@ -90,6 +90,9 @@ object ForestChangeDiagnosticAnalysis extends SummaryAnalysis {
           .persist(StorageLevel.MEMORY_AND_DISK)
       }
 
+    // If a location has empty ForestChangeDiagnosticData results, then the geometry
+    // must not have intersected the centroid of any pixels, so report the location
+    // as NoIntersectionError.
       partialResult.map {
         case Valid(Location(fid, data)) if data.equals(ForestChangeDiagnosticData.empty) =>
           Invalid(Location(fid, NoIntersectionError))

--- a/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardDF.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/gfwpro_dashboard/GfwProDashboardDF.scala
@@ -2,7 +2,7 @@ package org.globalforestwatch.summarystats.gfwpro_dashboard
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.globalforestwatch.features.{FeatureId, GfwProFeatureId, CombinedFeatureId, GadmFeatureId}
+import org.globalforestwatch.features.{FeatureId, GfwProFeatureId, CombinedFeatureId}
 import org.globalforestwatch.summarystats._
 import cats.data.Validated.{Valid, Invalid}
 import org.apache.spark.sql.functions.expr


### PR DESCRIPTION
In the AFi analysis, we currently don't return any row at all for a location whose geometry does not intersect the centroid of any pixel (mostly because the geometry is small compared to the pixel size). Add similar code as in FCD to detect this case and return NoIntersectionError.

Same change for GFWProDashboard as well.

I didn't make a common function for this, because the checks are slightly different between AFi, FCD, and Dashboard, and I think it's clearer to add a comment about this unusual case with the code being inline in the analysis.

Added a NoIntersection test for AFi.
