### PR TITLE
GTC-2631 Filter out VIIRS alerts more than 2yrs ago

### DIFF
--- a/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsExport.scala
+++ b/src/main/scala/org/globalforestwatch/summarystats/firealerts/FireAlertsExport.scala
@@ -4,6 +4,8 @@ import math.ceil
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.globalforestwatch.summarystats.SummaryExport
 import org.globalforestwatch.util.Util.getAnyMapValue
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 object FireAlertsExport extends SummaryExport {
 
@@ -39,9 +41,11 @@ object FireAlertsExport extends SummaryExport {
     gadmDF.cache()
 
     // only export all points for viirs gadm
+    val twoYearsAgo = LocalDate.now().minusYears(2)
     if (fireAlertType == "viirs") {
       gadmDF
         .coalesce(Integer.min(300, ceil (numPartitions / 20.0).toInt))
+        .filter($"alert__date" >= twoYearsAgo.format(DateTimeFormatter.ISO_LOCAL_DATE))
         .write
         .options (csvOptions)
         .csv (path = outputUrl + "/all")


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [GTC-2631](https://gfw.atlassian.net/browse/GTC-2631)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Filters out VIIRS alerts more than 2 years ago
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is part of the GADM 4.1 Update. By filtering out VIIRS alerts more than two years ago, we greatly reduce the number of features for summary calculations. Flagship is accommodating that. I also found no changes needed to `annualupdate_minimal` to use GADM 4.1, although AFI and FCD analyses do hard code some GADM 3.6 information that we'll need to change later. 

[GTC-2631]: https://gfw.atlassian.net/browse/GTC-2631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ