### PR TITLE
Skip using GDAL if GFW_SKIP_GDAL env variable is set.

### DIFF
--- a/src/main/scala/org/globalforestwatch/config/GfwConfig.scala
+++ b/src/main/scala/org/globalforestwatch/config/GfwConfig.scala
@@ -12,6 +12,16 @@ object GfwConfig {
     flag
   }
 
+  // True if the GFW_SKIP_GDAL environmental variable is set in any way. If this is
+  // true, then we avoid using GDAL by using GeoTiffRasterSource, rather than
+  // GDALRasterSource in loading tiffs. This is useful for local runs where the user
+  // doesn't have the right GDAL version, but results in much slower runs.
+  val skipGdalFlag: Boolean = {
+    val flag = scala.util.Properties.envOrNone("GFW_SKIP_GDAL") != None
+    println(s"GFW_SKIP_GDAL=$flag")
+    flag
+  }
+
   /** Read the configuration from the raster catalog. pinned specifies any entries using
    * 'latest' that should be pinned to a specified version, else use the actual
    * latest version of the dataset. */

--- a/src/main/scala/org/globalforestwatch/config/RasterCatalog.scala
+++ b/src/main/scala/org/globalforestwatch/config/RasterCatalog.scala
@@ -54,20 +54,30 @@ object RasterCatalog {
    * dataset in pinned, or determine the actual latest version and use that.
    */
   def getSourceUri(dataset: String, sourceUri: String, pinned: Option[NonEmptyList[Config]]): String = {
-    if (sourceUri.contains("latest")) {
+    // If we are skipping the use of GDAL, then replace any 'gdal-geotiff' folder in
+    // the URI with 'geotiff', since we won't be able to deal with special
+    // GDAL-optimized tiffs. This is a fairly special case, but it's only for local
+    // use where people don't want to set up the correct GDAL version.
+    val sourceUri2 = 
+      if (GfwConfig.skipGdalFlag) {
+        sourceUri.replace("/gdal-geotiff/", "/geotiff/")
+      } else {
+        sourceUri
+      }
+    if (sourceUri2.contains("latest")) {
       pinned match {
         case Some(list) => {
           list.toList.foreach(c => {
             if (c.key == dataset) {
-              return sourceUri.replace("latest", c.value)
+              return sourceUri2.replace("latest", c.value)
             }
           })
         }
         case None =>
       }
-      sourceUri.replace("latest", getLatestVersion(dataset))
+      sourceUri2.replace("latest", getLatestVersion(dataset))
     } else {
-      sourceUri
+      sourceUri2
     }
   }
 

--- a/src/main/scala/org/globalforestwatch/config/RasterCatalog.scala
+++ b/src/main/scala/org/globalforestwatch/config/RasterCatalog.scala
@@ -58,26 +58,26 @@ object RasterCatalog {
     // the URI with 'geotiff', since we won't be able to deal with special
     // GDAL-optimized tiffs. This is a fairly special case, but it's only for local
     // use where people don't want to set up the correct GDAL version.
-    val sourceUri2 = 
+    val correctSourceUri = 
       if (GfwConfig.skipGdalFlag) {
         sourceUri.replace("/gdal-geotiff/", "/geotiff/")
       } else {
         sourceUri
       }
-    if (sourceUri2.contains("latest")) {
+    if (correctSourceUri.contains("latest")) {
       pinned match {
         case Some(list) => {
           list.toList.foreach(c => {
             if (c.key == dataset) {
-              return sourceUri2.replace("latest", c.value)
+              return correctSourceUri.replace("latest", c.value)
             }
           })
         }
         case None =>
       }
-      sourceUri2.replace("latest", getLatestVersion(dataset))
+      correctSourceUri.replace("latest", getLatestVersion(dataset))
     } else {
-      sourceUri2
+      correctSourceUri
     }
   }
 

--- a/src/main/scala/org/globalforestwatch/layers/Layer.scala
+++ b/src/main/scala/org/globalforestwatch/layers/Layer.scala
@@ -7,6 +7,8 @@ import cats.implicits._
 import com.amazonaws.services.s3.AmazonS3URI
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import geotrellis.layer.{LayoutDefinition, LayoutTileSource, SpatialKey}
+import geotrellis.raster.RasterSource
+import geotrellis.raster.geotiff.GeoTiffRasterSource
 import geotrellis.raster.gdal.GDALRasterSource
 import org.globalforestwatch.config.GfwConfig
 import org.globalforestwatch.util.Config
@@ -197,7 +199,7 @@ trait RequiredLayer extends Layer {
     * so we only check the the associated tile exists) when fetchWindow is first
     * called, and then source is used to fetch the relevant tile.
     */
-  lazy val source: GDALRasterSource = {
+  lazy val source: RasterSource = {
     // Removes the expected 404 errors from console log
     val s3uri = new AmazonS3URI(uri)
     try {
@@ -225,7 +227,11 @@ trait RequiredLayer extends Layer {
     } catch {
       case e: AmazonS3Exception => throw new FileNotFoundException(uri)
     }
-    GDALRasterSource(uri)
+    if (GfwConfig.skipGdalFlag) {
+      GeoTiffRasterSource(uri)
+    } else {
+      GDALRasterSource(uri)
+    }
   }
 }
 
@@ -290,7 +296,7 @@ trait OptionalLayer extends Layer {
     * trying to open it, return None if no file found. source is only evaluated when
     * fetchWindow is first called, and then is used to fetch the relevant tile.
     */
-  lazy val source: Option[GDALRasterSource] = {
+  lazy val source: Option[RasterSource] = {
     // Removes the expected 404 errors from console log
 
     val s3uri = new AmazonS3URI(uri)
@@ -312,7 +318,11 @@ trait OptionalLayer extends Layer {
 
       if (keyExists) {
         println(s"Opening: $uri")
-        Some(GDALRasterSource(uri))
+        if (GfwConfig.skipGdalFlag) {
+          Some(GeoTiffRasterSource(uri))
+        } else {
+          Some(GDALRasterSource(uri))
+        }
       } else {
         println(s"Cannot open: $uri")
         None


### PR DESCRIPTION
Skip using GDAL if GFW_SKIP_GDAL env variable is set.

This is using the method that Justin used when he didn't have the right GDAL version. We avoid using GDAL by using GeoTiffRasterSource, rather than GDALRasterSource in loading tiffs in Layer.scala. This is useful for local runs where the user doesn't have the right GDAL version, but results in much slower runs (about 1.8x slower).

If we are skipping the use of GDAL, I automatically replace any 'gdal-geotiff' folder in the URI with 'geotiff', since we won't be able to deal with special GDAL-optimized tiffs. This is a fairly special case, but it's only for local use where people don't want to set up the correct GDAL version.
